### PR TITLE
add bind to device function

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -867,6 +867,72 @@ impl crate::Socket {
         unsafe { setsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_MARK, mark as c_int) }
     }
 
+    /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
+    ///
+    /// This value gets the socket binded device's interface name.
+    ///
+    /// This function is only available on Linux.
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    pub fn device(&self) -> io::Result<Option<String>> {
+        unsafe {
+            let mut opt_len = libc::IFNAMSIZ as libc::socklen_t;
+            let mut payload: MaybeUninit<[u8; libc::IFNAMSIZ]> = MaybeUninit::uninit();
+            syscall!(getsockopt(
+                self.inner,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                payload.as_mut_ptr().cast(),
+                &mut opt_len,
+            ))?;
+            match opt_len {
+                0 => Ok(None),
+                _ => {
+                    let end: usize = opt_len as usize - 1;
+                    match String::from_utf8(payload.assume_init()[..end].to_vec()) {
+                        Ok(interface) => Ok(Some(interface)),
+                        Err(_) => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Data not valid for the operation were encountered.",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Sets the value for the `SO_BINDTODEVICE` option on this socket.
+    ///
+    /// If a socket is bound to an interface, only packets received from that
+    /// particular interface are processed by the socket. Note that this only
+    /// works for some socket types, particularly AF_INET sockets. Accept an
+    /// Option where None which will set the length to zero, removing the
+    /// interface binding.
+    ///
+    /// This function is only available on Linux.
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    pub fn bind_device(&self, interface: Option<&str>) -> io::Result<()> {
+        unsafe {
+            let value = interface.unwrap_or_default();
+            let opt_len = value.len();
+            if opt_len > libc::IFNAMSIZ {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "interface name is too long",
+                ));
+            }
+            syscall!(setsockopt(
+                self.inner,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                value.as_ptr() as *const c_void,
+                opt_len as libc::socklen_t,
+            ))?;
+            Ok(())
+        }
+    }
+
     /// Get the value of the `SO_REUSEPORT` option on this socket.
     ///
     /// For more information about this option, see [`set_reuse_port`].


### PR DESCRIPTION
Bind a socket to a particular device like "eth0", as specified in the passed interface name. 

In some cases, we hope that the socket can be directly bound to the specified interface. All along, after the socket is created with `socket2`, we manually use `setsockopt` to bind. We hope to support this function on the official library.