### PR TITLE
Change Socket::recv to accept [MaybeUninit<u8>]

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -416,7 +416,7 @@ pub(crate) fn shutdown(fd: Socket, how: Shutdown) -> io::Result<()> {
     syscall!(shutdown(fd, how)).map(|_| ())
 }
 
-pub(crate) fn recv(fd: Socket, buf: &mut [u8], flags: c_int) -> io::Result<usize> {
+pub(crate) fn recv(fd: Socket, buf: &mut [MaybeUninit<u8>], flags: c_int) -> io::Result<usize> {
     syscall!(recv(
         fd,
         buf.as_mut_ptr().cast(),
@@ -426,7 +426,11 @@ pub(crate) fn recv(fd: Socket, buf: &mut [u8], flags: c_int) -> io::Result<usize
     .map(|n| n as usize)
 }
 
-pub(crate) fn recv_from(fd: Socket, buf: &mut [u8], flags: c_int) -> io::Result<(usize, SockAddr)> {
+pub(crate) fn recv_from(
+    fd: Socket,
+    buf: &mut [MaybeUninit<u8>],
+    flags: c_int,
+) -> io::Result<(usize, SockAddr)> {
     // Safety: `recvfrom` initialises the `SockAddr` for us.
     unsafe {
         SockAddr::init(|addr, addrlen| {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -273,7 +273,7 @@ pub(crate) fn shutdown(socket: Socket, how: Shutdown) -> io::Result<()> {
     syscall!(shutdown(socket, how), PartialEq::eq, sock::SOCKET_ERROR).map(|_| ())
 }
 
-pub(crate) fn recv(socket: Socket, buf: &mut [u8], flags: c_int) -> io::Result<usize> {
+pub(crate) fn recv(socket: Socket, buf: &mut [MaybeUninit<u8>], flags: c_int) -> io::Result<usize> {
     let res = syscall!(
         recv(
             socket,
@@ -325,7 +325,7 @@ pub(crate) fn recv_vectored(
 
 pub(crate) fn recv_from(
     socket: Socket,
-    buf: &mut [u8],
+    buf: &mut [MaybeUninit<u8>],
     flags: c_int,
 ) -> io::Result<(usize, SockAddr)> {
     // Safety: `recvfrom` initialises the `SockAddr` for us.


### PR DESCRIPTION
Allow uninitialised buffers to be used. Also in the following functions:

* Socket::recv_out_of_band
* Socket::recv_with_flags
* Socket::peek
* Socket::recv_from
* Socket::recv_from_with_flags
* Socket::peek_from