### PR TITLE
Enabled building on Fuschia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.81"
+libc = "0.2.82"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "ws2ipdef", "ws2tcpip"] }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # Targets available via Rustup that are supported.
-TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-pc-windows-msvc" "x86_64-sun-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-illumos" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd" "x86_64-unknown-redox"
-# TODO: add back "x86_64-fuchsia", tracked in
-# https://github.com/rust-lang/socket2/issues/179.
+TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-fuchsia" "x86_64-pc-windows-msvc" "x86_64-sun-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-illumos" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd" "x86_64-unknown-redox"
 
 test:
 	cargo test --all-features


### PR DESCRIPTION
This updates libc to 0.2.82 which has all the constants we required on
Fuschia.

Fixes #179.