### PR TITLE
Add AF_VSOCK support

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -463,8 +463,20 @@ impl SockAddr {
         }
         .map(|(_, addr)| addr)
     }
-}
 
+    /// Returns this address VSOCK CID/port if it is in the `AF_VSOCK` family,
+    /// otherwise return `None`.
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    pub fn vsock_address(&self) -> Option<(u32, u32)> {
+        if self.family() == libc::AF_VSOCK as sa_family_t {
+            // Safety: if the ss_family field is AF_VSOCK then storage must be a sockaddr_vm.
+            let addr = unsafe { &*(self.as_ptr() as *const libc::sockaddr_vm) };
+            Some((addr.svm_cid, addr.svm_port))
+        } else {
+            None
+        }
+    }
+}
 
 pub(crate) type Socket = c_int;
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -189,6 +189,14 @@ impl Domain {
         any(target_os = "android", target_os = "fuchsia", target_os = "linux")
     ))]
     pub const PACKET: Domain = Domain(libc::AF_PACKET);
+
+    /// Domain for low-level VSOCK interface, corresponding to `AF_VSOCK`.
+    ///
+    /// # Notes
+    ///
+    /// This function is only available on Linux.
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    pub const VSOCK: Domain = Domain(libc::AF_VSOCK);
 }
 
 impl_debug!(
@@ -198,6 +206,8 @@ impl_debug!(
     libc::AF_UNIX,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     libc::AF_PACKET,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    libc::AF_VSOCK,
     libc::AF_UNSPEC, // = 0.
 );
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -71,6 +71,8 @@ fn domain_fmt_debug() {
         (Domain::UNIX, "AF_UNIX"),
         #[cfg(all(feature = "all", any(target_os = "fuchsia", target_os = "linux")))]
         (Domain::PACKET, "AF_PACKET"),
+        #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+        (Domain::VSOCK, "AF_VSOCK"),
         (0.into(), "AF_UNSPEC"),
         (500.into(), "500"),
     ];

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -141,6 +141,7 @@ fn socket_address_vsock() {
     let addr = SockAddr::vsock(1, 9999).unwrap();
     assert!(addr.as_socket_ipv4().is_none());
     assert!(addr.as_socket_ipv6().is_none());
+    assert_eq!(addr.vsock_address().unwrap(), (1, 9999));
 }
 
 #[test]

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -136,6 +136,14 @@ fn socket_address_unix() {
 }
 
 #[test]
+#[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+fn socket_address_vsock() {
+    let addr = SockAddr::vsock(1, 9999).unwrap();
+    assert!(addr.as_socket_ipv4().is_none());
+    assert!(addr.as_socket_ipv6().is_none());
+}
+
+#[test]
 fn set_nonblocking() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
     assert_nonblocking(&socket, false);


### PR DESCRIPTION
"The VSOCK address family facilitates communication between virtual machines and the host they are running on.  This address family is used by guest agents and hypervisor services that need a communications channel that is in‐dependent of virtual machine network configuration." (vsock(7))

It is currently Linux-only here, but it should also be available for other systems, Windows and BSD in particular.