### PR TITLE
Add Socket::(set_)cpu_affinity

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1186,6 +1186,38 @@ impl crate::Socket {
         .map(|_| ())
     }
 
+    /// Get the value of the `SO_INCOMING_CPU` option on this socket.
+    ///
+    /// For more information about this option, see [`set_cpu_affinity`].
+    ///
+    /// This function is only available on Linux.
+    ///
+    /// [`set_cpu_affinity`]: crate::Socket::set_cpu_affinity
+    #[cfg(all(feature = "all", any(target_os = "linux")))]
+    pub fn cpu_affinity(&mut self) -> io::Result<usize> {
+        unsafe {
+            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_INCOMING_CPU)
+                .map(|cpu| cpu as usize)
+        }
+    }
+
+    /// Set value for the `SO_INCOMING_CPU` option on this socket.
+    ///
+    /// Sets the CPU affinity of the socket.
+    ///
+    /// This function is only available on Linux.
+    #[cfg(all(feature = "all", any(target_os = "linux")))]
+    pub fn set_cpu_affinity(&mut self, cpu: usize) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.inner,
+                libc::SOL_SOCKET,
+                libc::SO_INCOMING_CPU,
+                cpu as c_int,
+            )
+        }
+    }
+
     /// Get the value of the `SO_REUSEPORT` option on this socket.
     ///
     /// For more information about this option, see [`set_reuse_port`].

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -949,6 +949,19 @@ fn r#type() {
     assert_eq!(socket.r#type().unwrap(), Type::SEQPACKET);
 }
 
+#[cfg(all(feature = "all", target_os = "linux"))]
+#[test]
+fn cpu_affinity() {
+    let mut socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+
+    // NOTE: This requires at least 2 CPU cores.
+    let cpu = socket.cpu_affinity().unwrap();
+    let want = if cpu == 0 { 1 } else { 0 };
+
+    socket.set_cpu_affinity(want).unwrap();
+    assert_eq!(socket.cpu_affinity().unwrap(), want);
+}
+
 fn any_ipv4() -> SockAddr {
     SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into()
 }


### PR DESCRIPTION
Gets or sets the value of SO_INCOMING_CPU on Linux.