### PR TITLE
Fix Socket::(set_)cpu_affinity to take an immutable reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,3 +121,8 @@
 ## From v0.4.0-alpha.2 to v0.4.0-alpha.3
 
 * `Socket::connect_timeout` was added back.
+
+## From v0.4.0-alpha.4 to v0.4.0-alpha.5
+
+* Changed `Socket::set_cpu_affinity` and `Socket::cpu_affinity` to use an
+  immutable reference.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "socket2"
-version       = "0.4.0-alpha.4"
+version       = "0.4.0-alpha.5"
 authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1194,7 +1194,7 @@ impl crate::Socket {
     ///
     /// [`set_cpu_affinity`]: crate::Socket::set_cpu_affinity
     #[cfg(all(feature = "all", any(target_os = "linux")))]
-    pub fn cpu_affinity(&mut self) -> io::Result<usize> {
+    pub fn cpu_affinity(&self) -> io::Result<usize> {
         unsafe {
             getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_INCOMING_CPU)
                 .map(|cpu| cpu as usize)
@@ -1207,7 +1207,7 @@ impl crate::Socket {
     ///
     /// This function is only available on Linux.
     #[cfg(all(feature = "all", any(target_os = "linux")))]
-    pub fn set_cpu_affinity(&mut self, cpu: usize) -> io::Result<()> {
+    pub fn set_cpu_affinity(&self, cpu: usize) -> io::Result<()> {
         unsafe {
             setsockopt(
                 self.inner,


### PR DESCRIPTION
Pr #203 used mutable reference.