### PR TITLE
Fix breaking tests due to libc's deprecation of Musl time_t

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -769,6 +769,8 @@ pub(crate) fn set_timeout_opt(
 
 fn into_timeval(duration: Option<Duration>) -> libc::timeval {
     match duration {
+        // https://github.com/rust-lang/libc/issues/1848
+        #[cfg_attr(target_env = "musl", allow(deprecated))]
         Some(duration) => libc::timeval {
             tv_sec: min(duration.as_secs(), libc::time_t::max_value() as u64) as libc::time_t,
             tv_usec: duration.subsec_micros() as libc::suseconds_t,


### PR DESCRIPTION
Musl 1.2 has switched to 64 bit `time_t`, and `libc` crate is giving deprecation warning about it on Musl targets. This PR silences that this warnings so that it doesn't break tests.

libc issue: https://github.com/rust-lang/libc/issues/1848