### PR TITLE
Use 1.46 as Minimum Supported Rust Version (MSRV)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [stable, beta, nightly, macos, windows]
+        build: [stable, 1.46.0, beta, nightly, macos, windows]
         include:
           - build: stable
             os: ubuntu-latest
             rust: stable
+          - build: 1.46.0
+            os: ubuntu-latest
+            rust: 1.46.0
           - build: beta
             os: ubuntu-latest
             rust: beta

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ feature flag.
 * Redox
 * Solaris
 
+# Minimum Supported Rust Version (MSRV)
+
+Socket2 uses 1.46.0 as MSRV.
+
 # License
 
 This project is licensed under either of


### PR DESCRIPTION
This adds testing using rustc 1.46 in the CI.

This is now also a documented promise.