### PR TITLE
Fix endianness issues in sys::unix::in_addr_convertion test

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1449,13 +1449,13 @@ fn in_addr_convertion() {
     let raw = to_in_addr(&ip);
     // NOTE: `in_addr` is packed on NetBSD and it's unsafe to borrow.
     let a = raw.s_addr;
-    assert_eq!(a, 127 | 1 << 24);
+    assert_eq!(a, u32::from_ne_bytes([127, 0, 0, 1]));
     assert_eq!(from_in_addr(raw), ip);
 
     let ip = Ipv4Addr::new(127, 34, 4, 12);
     let raw = to_in_addr(&ip);
     let a = raw.s_addr;
-    assert_eq!(a, 127 << 0 | 34 << 8 | 4 << 16 | 12 << 24);
+    assert_eq!(a, u32::from_ne_bytes([127, 34, 4, 12]));
     assert_eq!(from_in_addr(raw), ip);
 }
 


### PR DESCRIPTION
Previously, the "expected" values were implicitly encoded in
little-endian byte order with bitwise operators to match the
native (little-endian) byte order of u32s on most architectures.
This test obviously breaks when the byte order is big-endian.

Instead, convert the tested address u32 into "network endian"
bytes, and provide the expected value as an array of numbers,
as well. This has the added benefit that it's much clearer to
read, and the numbers in the array also match the ones that are
used in the Ipv4Addr constructor, and no longer have to be
constructed manually, in reverse order, with bitwise operators.

Fixes #216