### PR TITLE
Enable Socket::r#type on all platforms

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -280,6 +280,12 @@ impl Socket {
         sys::getpeername(self.inner)
     }
 
+    /// Returns the [`Type`] of this socket by checking the `SO_TYPE` option on
+    /// this socket.
+    pub fn r#type(&self) -> io::Result<Type> {
+        unsafe { getsockopt::<c_int>(self.inner, sys::SOL_SOCKET, sys::SO_TYPE).map(Type) }
+    }
+
     /// Creates a new independently owned handle to the underlying socket.
     ///
     /// # Notes

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -82,7 +82,7 @@ pub(crate) use libc::{
     IPV6_MULTICAST_HOPS, IPV6_MULTICAST_IF, IPV6_MULTICAST_LOOP, IPV6_UNICAST_HOPS, IPV6_V6ONLY,
     IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP, IP_MULTICAST_IF, IP_MULTICAST_LOOP, IP_MULTICAST_TTL,
     IP_TTL, MSG_OOB, MSG_PEEK, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_KEEPALIVE, SO_RCVBUF,
-    SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, TCP_NODELAY,
+    SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
 };
 #[cfg(not(any(
     target_os = "dragonfly",
@@ -1079,21 +1079,6 @@ impl crate::Socket {
                 p => Some(Protocol(p)),
             })
         }
-    }
-
-    /// Returns the [`Type`] of this socket by checking the `SO_TYPE` option on
-    /// this socket.
-    #[cfg(all(
-        feature = "all",
-        any(
-            target_os = "android",
-            target_os = "freebsd",
-            target_os = "fuchsia",
-            target_os = "linux",
-        )
-    ))]
-    pub fn r#type(&self) -> io::Result<Type> {
-        unsafe { getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_TYPE).map(Type) }
     }
 
     /// Gets the value for the `SO_MARK` option on this socket.

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -64,7 +64,7 @@ pub(crate) use winapi::um::ws2tcpip::socklen_t;
 // Used in `Socket`.
 pub(crate) use winapi::shared::ws2def::{
     IPPROTO_IP, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_KEEPALIVE, SO_LINGER, SO_OOBINLINE,
-    SO_RCVBUF, SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, TCP_NODELAY,
+    SO_RCVBUF, SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
 };
 pub(crate) use winapi::shared::ws2ipdef::{
     IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP, IPV6_MREQ as Ipv6Mreq, IPV6_MULTICAST_HOPS,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -924,15 +924,6 @@ fn protocol() {
     assert_eq!(socket.protocol().unwrap(), Some(Protocol::UDP));
 }
 
-#[cfg(all(
-    feature = "all",
-    any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "fuchsia",
-        target_os = "linux",
-    )
-))]
 #[test]
 fn r#type() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
@@ -941,8 +932,12 @@ fn r#type() {
     let socket = Socket::new(Domain::IPV6, Type::DGRAM, None).unwrap();
     assert_eq!(socket.r#type().unwrap(), Type::DGRAM);
 
-    let socket = Socket::new(Domain::UNIX, Type::SEQPACKET, None).unwrap();
-    assert_eq!(socket.r#type().unwrap(), Type::SEQPACKET);
+    // macos doesn't support seqpacket
+    #[cfg(all(unix, not(target_vendor = "apple"), feature = "all"))]
+    {
+        let socket = Socket::new(Domain::UNIX, Type::SEQPACKET, None).unwrap();
+        assert_eq!(socket.r#type().unwrap(), Type::SEQPACKET);
+    }
 }
 
 #[cfg(all(feature = "all", target_os = "linux"))]


### PR DESCRIPTION
As far as I can tell `SO_TYPE` is defined on all platforms (though maybe CI will prove me wrong? :upside_down_face:), it's just `SO_PROTOCOL`/`SO_DOMAIN` that are specific to linux/freebsd/etc.