### PR TITLE
Allow for niche optimization on Unix platforms

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -74,7 +74,7 @@ pub struct Socket {
 /// Store a `TcpStream` internally to take advantage of its niche optimizations on Unix platforms.
 pub(crate) type Inner = std::net::TcpStream;
 
-// The `sys` module must have access to these functions.
+// The `sys` module must have access to the below three functions.
 impl Socket {
     pub(crate) fn from_raw(raw: sys::Socket) -> Socket {
         Socket {
@@ -87,9 +87,7 @@ impl Socket {
     pub(crate) fn into_raw(self) -> sys::Socket {
         sys::socket_into_raw(self.inner)
     }
-}
 
-impl Socket {
     /// Creates a new socket and sets common flags.
     ///
     /// This function corresponds to `socket(2)` on Unix and `WSASocketW` on

--- a/src/sockref.rs
+++ b/src/sockref.rs
@@ -105,7 +105,7 @@ where
 impl fmt::Debug for SockRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SockRef")
-            .field("raw", &self.socket.inner)
+            .field("raw", &self.socket.as_raw())
             .field("local_addr", &self.socket.local_addr().ok())
             .field("peer_addr", &self.socket.peer_addr().ok())
             .finish()

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -485,9 +485,11 @@ pub(crate) type Socket = c_int;
 pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
     unsafe { crate::socket::Inner::from_raw_fd(socket) }
 }
+
 pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {
     socket.as_raw_fd()
 }
+
 pub(crate) fn socket_into_raw(socket: crate::socket::Inner) -> Socket {
     socket.into_raw_fd()
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -482,6 +482,16 @@ impl SockAddr {
 
 pub(crate) type Socket = c_int;
 
+pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
+    unsafe { crate::socket::Inner::from_raw_fd(socket) }
+}
+pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {
+    socket.as_raw_fd()
+}
+pub(crate) fn socket_into_raw(socket: crate::socket::Inner) -> Socket {
+    socket.into_raw_fd()
+}
+
 pub(crate) fn socket(family: c_int, ty: c_int, protocol: c_int) -> io::Result<Socket> {
     syscall!(socket(family, ty, protocol))
 }
@@ -504,7 +514,7 @@ pub(crate) fn poll_connect(socket: &crate::Socket, timeout: Duration) -> io::Res
     let start = Instant::now();
 
     let mut pollfd = libc::pollfd {
-        fd: socket.inner,
+        fd: socket.as_raw(),
         events: libc::POLLIN | libc::POLLOUT,
         revents: 0,
     };
@@ -884,12 +894,6 @@ pub(crate) unsafe fn setsockopt<T>(
     .map(|_| ())
 }
 
-pub(crate) fn close(fd: Socket) {
-    unsafe {
-        let _ = libc::close(fd);
-    }
-}
-
 pub(crate) fn to_in_addr(addr: &Ipv4Addr) -> in_addr {
     // `s_addr` is stored as BE on all machines, and the array is in BE order.
     // So the native endian conversion method is used so that it's never
@@ -953,8 +957,8 @@ impl crate::Socket {
         // Safety: `accept4` initialises the `SockAddr` for us.
         unsafe {
             SockAddr::init(|storage, len| {
-                syscall!(accept4(self.inner, storage.cast(), len, flags))
-                    .map(|inner| crate::Socket { inner })
+                syscall!(accept4(self.as_raw(), storage.cast(), len, flags))
+                    .map(crate::Socket::from_raw)
             })
         }
     }
@@ -971,9 +975,19 @@ impl crate::Socket {
 
     pub(crate) fn _set_cloexec(&self, close_on_exec: bool) -> io::Result<()> {
         if close_on_exec {
-            fcntl_add(self.inner, libc::F_GETFD, libc::F_SETFD, libc::FD_CLOEXEC)
+            fcntl_add(
+                self.as_raw(),
+                libc::F_GETFD,
+                libc::F_SETFD,
+                libc::FD_CLOEXEC,
+            )
         } else {
-            fcntl_remove(self.inner, libc::F_GETFD, libc::F_SETFD, libc::FD_CLOEXEC)
+            fcntl_remove(
+                self.as_raw(),
+                libc::F_GETFD,
+                libc::F_SETFD,
+                libc::FD_CLOEXEC,
+            )
         }
     }
 
@@ -991,7 +1005,7 @@ impl crate::Socket {
     pub(crate) fn _set_nosigpipe(&self, nosigpipe: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::SOL_SOCKET,
                 libc::SO_NOSIGPIPE,
                 nosigpipe as c_int,
@@ -1007,7 +1021,7 @@ impl crate::Socket {
     #[cfg(all(feature = "all", not(target_os = "redox")))]
     pub fn mss(&self) -> io::Result<u32> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::IPPROTO_TCP, libc::TCP_MAXSEG)
+            getsockopt::<c_int>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_MAXSEG)
                 .map(|mss| mss as u32)
         }
     }
@@ -1020,7 +1034,7 @@ impl crate::Socket {
     pub fn set_mss(&self, mss: u32) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::IPPROTO_TCP,
                 libc::TCP_MAXSEG,
                 mss as c_int,
@@ -1041,7 +1055,8 @@ impl crate::Socket {
     ))]
     pub fn is_listener(&self) -> io::Result<bool> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_ACCEPTCONN).map(|v| v != 0)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_ACCEPTCONN)
+                .map(|v| v != 0)
         }
     }
 
@@ -1058,7 +1073,7 @@ impl crate::Socket {
         )
     ))]
     pub fn domain(&self) -> io::Result<Domain> {
-        unsafe { getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_DOMAIN).map(Domain) }
+        unsafe { getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_DOMAIN).map(Domain) }
     }
 
     /// Returns the [`Protocol`] of this socket by checking the `SO_PROTOCOL`
@@ -1074,7 +1089,8 @@ impl crate::Socket {
     ))]
     pub fn protocol(&self) -> io::Result<Option<Protocol>> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_PROTOCOL).map(|v| match v {
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_PROTOCOL).map(|v| match v
+            {
                 0 => None,
                 p => Some(Protocol(p)),
             })
@@ -1094,7 +1110,8 @@ impl crate::Socket {
     ))]
     pub fn mark(&self) -> io::Result<u32> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_MARK).map(|mark| mark as u32)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_MARK)
+                .map(|mark| mark as u32)
         }
     }
 
@@ -1111,7 +1128,14 @@ impl crate::Socket {
         any(target_os = "android", target_os = "fuchsia", target_os = "linux")
     ))]
     pub fn set_mark(&self, mark: u32) -> io::Result<()> {
-        unsafe { setsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_MARK, mark as c_int) }
+        unsafe {
+            setsockopt::<c_int>(
+                self.as_raw(),
+                libc::SOL_SOCKET,
+                libc::SO_MARK,
+                mark as c_int,
+            )
+        }
     }
 
     /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
@@ -1130,7 +1154,7 @@ impl crate::Socket {
         let mut len = buf.len() as libc::socklen_t;
         unsafe {
             syscall!(getsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::SOL_SOCKET,
                 libc::SO_BINDTODEVICE,
                 buf.as_mut_ptr().cast(),
@@ -1166,7 +1190,7 @@ impl crate::Socket {
             (ptr::null(), 0)
         };
         syscall!(setsockopt(
-            self.inner,
+            self.as_raw(),
             libc::SOL_SOCKET,
             libc::SO_BINDTODEVICE,
             value.cast(),
@@ -1185,7 +1209,7 @@ impl crate::Socket {
     #[cfg(all(feature = "all", any(target_os = "linux")))]
     pub fn cpu_affinity(&self) -> io::Result<usize> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_INCOMING_CPU)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_INCOMING_CPU)
                 .map(|cpu| cpu as usize)
         }
     }
@@ -1199,7 +1223,7 @@ impl crate::Socket {
     pub fn set_cpu_affinity(&self, cpu: usize) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::SOL_SOCKET,
                 libc::SO_INCOMING_CPU,
                 cpu as c_int,
@@ -1220,7 +1244,7 @@ impl crate::Socket {
     ))]
     pub fn reuse_port(&self) -> io::Result<bool> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::SO_REUSEPORT)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_REUSEPORT)
                 .map(|reuse| reuse != 0)
         }
     }
@@ -1239,7 +1263,7 @@ impl crate::Socket {
     pub fn set_reuse_port(&self, reuse: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::SOL_SOCKET,
                 libc::SO_REUSEPORT,
                 reuse as c_int,
@@ -1260,7 +1284,7 @@ impl crate::Socket {
     ))]
     pub fn freebind(&self) -> io::Result<bool> {
         unsafe {
-            getsockopt::<c_int>(self.inner, libc::SOL_SOCKET, libc::IP_FREEBIND)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::IP_FREEBIND)
                 .map(|reuse| reuse != 0)
         }
     }
@@ -1281,7 +1305,7 @@ impl crate::Socket {
     pub fn set_freebind(&self, reuse: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 libc::SOL_SOCKET,
                 libc::IP_FREEBIND,
                 reuse as c_int,
@@ -1344,7 +1368,7 @@ impl crate::Socket {
         };
         syscall!(sendfile(
             file,
-            self.inner,
+            self.as_raw(),
             offset,
             &mut length,
             ptr::null_mut(),
@@ -1366,7 +1390,7 @@ impl crate::Socket {
             None => 0x7ffff000, // 2,147,479,552 bytes.
         };
         let mut offset = offset;
-        syscall!(sendfile(self.inner, file, &mut offset, count)).map(|n| n as usize)
+        syscall!(sendfile(self.as_raw(), file, &mut offset, count)).map(|n| n as usize)
     }
 
     #[cfg(all(feature = "all", target_os = "freebsd"))]
@@ -1384,7 +1408,7 @@ impl crate::Socket {
         let mut sbytes: libc::off_t = 0;
         syscall!(sendfile(
             file,
-            self.inner,
+            self.as_raw(),
             offset,
             nbytes,
             ptr::null_mut(),
@@ -1397,21 +1421,19 @@ impl crate::Socket {
 
 impl AsRawFd for crate::Socket {
     fn as_raw_fd(&self) -> c_int {
-        self.inner
+        self.as_raw()
     }
 }
 
 impl IntoRawFd for crate::Socket {
     fn into_raw_fd(self) -> c_int {
-        let fd = self.inner;
-        mem::forget(self);
-        fd
+        self.into_raw()
     }
 }
 
 impl FromRawFd for crate::Socket {
     unsafe fn from_raw_fd(fd: c_int) -> crate::Socket {
-        crate::Socket { inner: fd }
+        crate::Socket::from_raw(fd)
     }
 }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -193,9 +193,11 @@ pub(crate) type Socket = sock::SOCKET;
 pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
     unsafe { crate::socket::Inner::from_raw_socket(socket as RawSocket) }
 }
+
 pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {
     socket.as_raw_socket() as Socket
 }
+
 pub(crate) fn socket_into_raw(socket: crate::socket::Inner) -> Socket {
     socket.into_raw_socket() as Socket
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -190,6 +190,16 @@ fn init() {
 
 pub(crate) type Socket = sock::SOCKET;
 
+pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
+    unsafe { crate::socket::Inner::from_raw_socket(socket as RawSocket) }
+}
+pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {
+    socket.as_raw_socket() as Socket
+}
+pub(crate) fn socket_into_raw(socket: crate::socket::Inner) -> Socket {
+    socket.into_raw_socket() as Socket
+}
+
 pub(crate) fn socket(family: c_int, mut ty: c_int, protocol: c_int) -> io::Result<Socket> {
     init();
 
@@ -227,7 +237,7 @@ pub(crate) fn poll_connect(socket: &crate::Socket, timeout: Duration) -> io::Res
     let start = Instant::now();
 
     let mut fd_array = WSAPOLLFD {
-        fd: socket.inner,
+        fd: socket.as_raw(),
         events: POLLRDNORM | POLLWRNORM,
         revents: 0,
     };
@@ -698,12 +708,6 @@ fn ioctlsocket(socket: Socket, cmd: c_long, payload: &mut u_long) -> io::Result<
     .map(|_| ())
 }
 
-pub(crate) fn close(socket: Socket) {
-    unsafe {
-        let _ = sock::closesocket(socket);
-    }
-}
-
 pub(crate) fn to_in_addr(addr: &Ipv4Addr) -> IN_ADDR {
     let mut s_un: in_addr_S_un = unsafe { mem::zeroed() };
     // `S_un` is stored as BE on all machines, and the array is in BE order. So
@@ -741,7 +745,7 @@ impl crate::Socket {
         // `sock::` path.
         let res = unsafe {
             SetHandleInformation(
-                self.inner as HANDLE,
+                self.as_raw() as HANDLE,
                 winbase::HANDLE_FLAG_INHERIT,
                 !no_inherit as _,
             )
@@ -757,23 +761,19 @@ impl crate::Socket {
 
 impl AsRawSocket for crate::Socket {
     fn as_raw_socket(&self) -> RawSocket {
-        self.inner as RawSocket
+        self.as_raw() as RawSocket
     }
 }
 
 impl IntoRawSocket for crate::Socket {
     fn into_raw_socket(self) -> RawSocket {
-        let socket = self.inner;
-        mem::forget(self);
-        socket as RawSocket
+        self.into_raw() as RawSocket
     }
 }
 
 impl FromRawSocket for crate::Socket {
     unsafe fn from_raw_socket(socket: RawSocket) -> crate::Socket {
-        crate::Socket {
-            inner: socket as Socket,
-        }
+        crate::Socket::from_raw(socket as Socket)
     }
 }
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -14,8 +14,8 @@ use std::io::IoSlice;
 #[cfg(all(unix, feature = "all"))]
 use std::io::Read;
 use std::io::Write;
-use std::mem::MaybeUninit;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::mem::{self, MaybeUninit};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
 #[cfg(not(target_os = "redox"))]
 use std::net::{Ipv6Addr, SocketAddrV6};
 #[cfg(all(
@@ -954,12 +954,10 @@ fn cpu_affinity() {
 }
 
 #[test]
-#[cfg(unix)]
 fn niche() {
-    assert_eq!(
-        std::mem::size_of::<Option<Socket>>(),
-        std::mem::size_of::<Socket>()
-    );
+    if mem::size_of::<Option<TcpStream>>() == mem::size_of::<TcpStream>() {
+        assert_eq!(mem::size_of::<Option<Socket>>(), mem::size_of::<Socket>());
+    }
 }
 
 fn any_ipv4() -> SockAddr {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -953,6 +953,15 @@ fn cpu_affinity() {
     assert_eq!(socket.cpu_affinity().unwrap(), want);
 }
 
+#[test]
+#[cfg(unix)]
+fn niche() {
+    assert_eq!(
+        std::mem::size_of::<Option<Socket>>(),
+        std::mem::size_of::<Socket>()
+    );
+}
+
 fn any_ipv4() -> SockAddr {
     SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into()
 }


### PR DESCRIPTION
The standard library's file descriptor types have a niche of -1, allowing `Option<T>` to have the same size as `T`. By storing a `TcpStream` internally instead of a raw file descriptor, `Socket` can also take advantage of this. Currently, this incurs a slightly cost as `{from, as, into}_raw_{fd, socket}` won't be inlined, however if [this Rust PR](https://github.com/rust-lang/rust/pull/84541) is merged it will be. Storing a `TcpStream` also allows for closing to be implemented by the standard library instead of this one, which is a nice benefit.