### PR TITLE
support setting IP_TRANSPARENT on sockets

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -968,9 +968,8 @@ impl Socket {
         }
     }
 
-    /// Set the value of the `IP_TRANSPARENTF` option on this socket.
+    /// Set the value of the `IP_TRANSPARENT` option on this socket.
     ///
-    /// IP_TRANSPARENT (since Linux 2.6.24)
     /// Setting this boolean option enables transparent proxying
     /// on this socket.  This socket option allows the calling
     /// application to bind to a nonlocal IP address and operate

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -898,6 +898,8 @@ impl Socket {
     ///
     /// TProxy redirection with the iptables TPROXY target also
     /// requires that this option be set on the redirected socket.
+    /// this feature is only available on linux
+    #[cfg(any(target_os = "linux"))]
     pub fn set_ip_transparent(&self) -> io::Result<()> {
         unsafe {
             setsockopt(

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -955,7 +955,7 @@ fn into_linger(duration: Option<Duration>) -> sys::linger {
 /// * Linux: <https://man7.org/linux/man-pages/man7/ip.7.html>
 /// * Windows: <https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options>
 impl Socket {
-    /// Get the value of the `IP_TRANSPARENTF` option on this socket.
+    /// Get the value of the `IP_TRANSPARENT` option on this socket.
     ///
     /// For more information about this option, see [`set_ip_transparent`].
     ///

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -968,6 +968,8 @@ impl Socket {
         }
     }
 
+    /// Set the value of the `IP_TRANSPARENTF` option on this socket.
+    ///
     /// IP_TRANSPARENT (since Linux 2.6.24)
     /// Setting this boolean option enables transparent proxying
     /// on this socket.  This socket option allows the calling

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -884,6 +884,31 @@ impl Socket {
         }
     }
 
+    /// IP_TRANSPARENT (since Linux 2.6.24)
+    /// Setting this boolean option enables transparent proxying
+    /// on this socket.  This socket option allows the calling
+    /// application to bind to a nonlocal IP address and operate
+    /// both as a client and a server with the foreign address as
+    /// the local endpoint.  NOTE: this requires that routing be
+    /// set up in a way that packets going to the foreign address
+    /// are routed through the TProxy box (i.e., the system
+    /// hosting the application that employs the IP_TRANSPARENT
+    /// socket option).  Enabling this socket option requires
+    /// superuser privileges (the CAP_NET_ADMIN capability).
+    ///
+    /// TProxy redirection with the iptables TPROXY target also
+    /// requires that this option be set on the redirected socket.
+    pub fn set_ip_transparent(&self) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.inner,
+                sys::IPPROTO_IP,
+                libc::IP_TRANSPARENT,
+                1 as c_int,
+            )
+        }
+    }
+
     /// Get the value of the `SO_SNDBUF` option on this socket.
     ///
     /// For more information about this option, see [`set_send_buffer_size`].

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -900,14 +900,22 @@ impl Socket {
     /// requires that this option be set on the redirected socket.
     /// this feature is only available on linux
     #[cfg(any(target_os = "linux"))]
-    pub fn set_ip_transparent(&self) -> io::Result<()> {
+    pub fn set_ip_transparent(&self, transparent: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
                 self.inner,
                 sys::IPPROTO_IP,
                 libc::IP_TRANSPARENT,
-                1 as c_int,
+                transparent as c_int,
             )
+        }
+    }
+    /// Get whether the IP_TRANSPARENT is set for this socket.
+    #[cfg(any(target_os = "linux"))]
+    pub fn ip_transparent(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.inner, sys::IPPROTO_IP, libc::IP_TRANSPARENT)
+                .map(|transparent| transparent != 0)
         }
     }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -963,7 +963,7 @@ impl Socket {
     #[cfg(all(feature = "all", target_os = "linux"))]
     pub fn ip_transparent(&self) -> io::Result<bool> {
         unsafe {
-            getsockopt::<c_int>(self.inner, sys::IPPROTO_IP, libc::IP_TRANSPARENT)
+            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IP, libc::IP_TRANSPARENT)
                 .map(|transparent| transparent != 0)
         }
     }
@@ -988,7 +988,7 @@ impl Socket {
     pub fn set_ip_transparent(&self, transparent: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
-                self.inner,
+                self.as_raw(),
                 sys::IPPROTO_IP,
                 libc::IP_TRANSPARENT,
                 transparent as c_int,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1047,7 +1047,7 @@ test!(
     mss,
     set_mss(256)
 );
-#[cfg(any(target_os = "linux"))]
+#[cfg(all(feature = "all", target_os = "linux"))]
 test!(
     #[ignore = "setting `IP_TRANSPARENT` requires the `CAP_NET_ADMIN` capability (works when running as root)"]
     ip_transparent,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1047,6 +1047,12 @@ test!(
     mss,
     set_mss(256)
 );
+#[cfg(any(target_os = "linux"))]
+test!(
+    #[ignore = "setting `IP_TRANSPARENT` requires the `CAP_NET_ADMIN` capability (works when running as root)"]
+    ip_transparent,
+    set_ip_transparent(true)
+);
 #[cfg(all(feature = "all", any(target_os = "fuchsia", target_os = "linux")))]
 test!(
     #[ignore = "setting `SO_MARK` requires the `CAP_NET_ADMIN` capability (works when running as root)"]


### PR DESCRIPTION
This allows you to set IP_TRANSPARENT on sockets for linux.

To setup for a local proxy you can use the following:
ref: https://powerdns.org/tproxydoc/tproxy.md.html

```
    export OUTBOUND_PORT=3100
    export PROXY_PORT=3000
    # move anything marked with a 1 --> table #100
    sudo ip rule add fwmark 1 lookup 100
    # table 100, treat all addrs as local loopback
    sudo ip route add local 0.0.0.0/0 dev lo table 100

    # all inbound traffic on $OUTBOUND_PORT should forward to localhost $PROXY_PORT transparently
    sudo iptables -t mangle -I POSTROUTING -p tcp --dport $OUTBOUND_PORT -j TPROXY --tproxy-mark 0x1/0x1 --on-port=$PROXY_PORT --on-ip=127.0.0.1

    # all output traffic for $OUTBOUND_PORT will get marked and sent to table #100 (loopback)
    sudo iptables -t mangle -A OUTPUT -p tcp -m tcp --dport $OUTBOUND_PORT -j MARK --set-mark 1
```

Once done, then newly accept()'ed sockets will have the local_addr() set to the originally requested address and not the currently bound listening address.