### PR TITLE
Support infallible SockAddr creation

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -18,6 +18,7 @@ pub struct SockAddr {
     len: socklen_t,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl SockAddr {
     /// Initialise a `SockAddr` by calling the function `init`.
     ///

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -12,7 +12,7 @@ use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH_u;
 /// The address of a socket.
 ///
 /// `SockAddr`s may be constructed directly to and from the standard library
-/// `SocketAddr`, `SocketAddrV4`, and `SocketAddrV6` types.
+/// [`SocketAddr`], [`SocketAddrV4`], and [`SocketAddrV6`] types.
 pub struct SockAddr {
     storage: sockaddr_storage,
     len: socklen_t,
@@ -59,7 +59,7 @@ impl SockAddr {
     /// # drop(address);
     /// # Ok(())
     /// # }
-    /// ```
+    #[doc = "```"]
     pub unsafe fn init<F, T>(init: F) -> io::Result<(T, SockAddr)>
     where
         F: FnOnce(*mut sockaddr_storage, *mut socklen_t) -> io::Result<T>,
@@ -137,7 +137,7 @@ impl SockAddr {
         }
     }
 
-    /// Returns this address as a `SocketAddrV4` if it is in the `AF_INET`
+    /// Returns this address as a [`SocketAddrV4`] if it is in the `AF_INET`
     /// family.
     pub fn as_socket_ipv4(&self) -> Option<SocketAddrV4> {
         match self.as_socket() {
@@ -146,7 +146,7 @@ impl SockAddr {
         }
     }
 
-    /// Returns this address as a `SocketAddrV6` if it is in the `AF_INET6`
+    /// Returns this address as a [`SocketAddrV6`] if it is in the `AF_INET6`
     /// family.
     pub fn as_socket_ipv6(&self) -> Option<SocketAddrV6> {
         match self.as_socket() {

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -45,7 +45,7 @@ impl SockAddr {
     ///
     /// // Initialise a `SocketAddr` byte calling `getsockname(2)`.
     /// let mut addr_storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
-    /// let mut len = 0;
+    /// let mut len = mem::size_of_val(&addr_storage) as libc::socklen_t;
     ///
     /// // The `getsockname(2)` system call will intiliase `storage` for
     /// // us, setting `len` to the correct length.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -655,6 +655,7 @@ fn set_common_type(ty: Type) -> Type {
 
 /// Set `FD_CLOEXEC` and `NOSIGPIPE` on the `socket` for platforms that need it.
 #[inline(always)]
+#[allow(clippy::unnecessary_wraps)]
 fn set_common_flags(socket: Socket) -> io::Result<Socket> {
     // On platforms that don't have `SOCK_CLOEXEC` use `FD_CLOEXEC`.
     #[cfg(all(

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -444,11 +444,6 @@ impl SockAddr {
     /// Constructs a `SockAddr` with the family `AF_VSOCK` and the provided CID/port.
     ///
     /// This function is only available on Linux.
-    ///
-    /// # Errors
-    ///
-    /// This function can never fail. In a future version of this library it will be made
-    /// infallible.
     #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
     #[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
     pub fn vsock(cid: u32, port: u32) -> io::Result<SockAddr> {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -444,6 +444,11 @@ impl SockAddr {
     /// Constructs a `SockAddr` with the family `AF_VSOCK` and the provided CID/port.
     ///
     /// This function is only available on Linux.
+    ///
+    /// # Errors
+    ///
+    /// This function can never fail. In a future version of this library it will be made
+    /// infallible.
     #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
     #[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
     pub fn vsock(cid: u32, port: u32) -> io::Result<SockAddr> {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -389,7 +389,7 @@ fn connect_timeout_valid() {
 #[cfg(all(feature = "all", unix))]
 fn pair() {
     let (mut a, mut b) = Socket::pair(Domain::UNIX, Type::STREAM, None).unwrap();
-    a.write(DATA).unwrap();
+    let _ = a.write(DATA).unwrap();
     let mut buf = [0; DATA.len() + 1];
     let n = b.read(&mut buf).unwrap();
     assert_eq!(n, DATA.len());
@@ -415,7 +415,7 @@ fn unix() {
     a.connect(&addr).unwrap();
     let mut b = listener.accept().unwrap().0;
 
-    a.write(DATA).unwrap();
+    let _ = a.write(DATA).unwrap();
     let mut buf = [0; DATA.len() + 1];
     let n = b.read(&mut buf).unwrap();
     assert_eq!(n, DATA.len());
@@ -438,7 +438,7 @@ fn vsock() {
     a.connect(&addr).unwrap();
     let mut b = listener.accept().unwrap().0;
 
-    a.write(DATA).unwrap();
+    let _ = a.write(DATA).unwrap();
     let mut buf = [0; DATA.len() + 1];
     let n = b.read(&mut buf).unwrap();
     assert_eq!(n, DATA.len());
@@ -943,7 +943,7 @@ fn r#type() {
 #[cfg(all(feature = "all", target_os = "linux"))]
 #[test]
 fn cpu_affinity() {
-    let mut socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
 
     // NOTE: This requires at least 2 CPU cores.
     let cpu = socket.cpu_affinity().unwrap();


### PR DESCRIPTION
- I renamed `SockAddr::init` to `SockAddr::try_init`, to support the addition of an infallible `SockAddr::init`.
- `SockAddr::vsock` can now be made to be infallible by using `SockAddr::init`.
- `SockAddr::try_init` now supports a generic error type, not just `io::Error` for additional flexibility.