### PR TITLE
Document `SockAddr::vsock` as infallible

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -444,6 +444,11 @@ impl SockAddr {
     /// Constructs a `SockAddr` with the family `AF_VSOCK` and the provided CID/port.
     ///
     /// This function is only available on Linux.
+    ///
+    /// # Errors
+    ///
+    /// This function can never fail. In a future version of this library it will be made
+    /// infallible.
     #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
     #[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
     pub fn vsock(cid: u32, port: u32) -> io::Result<SockAddr> {


### PR DESCRIPTION
Split off from #228. `SockAddr::vsock` can never fail, so this makes that clear to users while avoiding breaking changes.