### PR TITLE
Add DragonFly support for KEEPINTVL/KEEPCNT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,7 @@ impl TcpKeepalive {
     #[cfg(all(
         feature = "all",
         any(
+            target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",
@@ -383,6 +384,7 @@ impl TcpKeepalive {
     #[cfg(all(
         feature = "all",
         any(
+            target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -112,6 +112,7 @@ pub(crate) use libc::{
     feature = "all",
     any(
         target_os = "android",
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "fuchsia",
         target_os = "illumos",

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -683,6 +683,7 @@ fn tcp_keepalive() {
     #[cfg(all(
         feature = "all",
         any(
+            target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",
@@ -696,6 +697,7 @@ fn tcp_keepalive() {
     #[cfg(all(
         feature = "all",
         any(
+            target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "linux",
@@ -1090,8 +1092,20 @@ test!(IPv4 ttl, set_ttl(40));
 test!(IPv4 broadcast, set_broadcast(true));
 
 test!(IPv6 unicast_hops_v6, set_unicast_hops_v6(20));
-#[cfg(not(any(windows, target_os = "freebsd")))]
+#[cfg(not(any(
+    windows,
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+    )
+)))]
 test!(IPv6 only_v6, set_only_v6(true));
 // IPv6 socket are already IPv6 only on FreeBSD and Windows.
-#[cfg(any(windows, target_os = "freebsd"))]
+#[cfg(any(
+    windows,
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+    )
+))]
 test!(IPv6 only_v6, set_only_v6(false));

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1104,7 +1104,7 @@ test!(IPv6 only_v6, set_only_v6(true));
 #[cfg(any(
     windows,
     any(
-        target_os = "dragonfly",
+        // target_os = "dragonfly", // unsetting only_v6 is unsupported on DragonflyBSD
         target_os = "freebsd",
     )
 ))]


### PR DESCRIPTION
Those are supported on DragonFly, build fails without them.

Not sure what to do with test, mine showing:

```
---- only_v6 stdout ----
thread 'only_v6' panicked at 'assertion failed: `(left != right)`
  left: `true`,
 right: `true`: initial value and argument are the same', tests/socket.rs:1094:1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tcp_keepalive stdout ----
thread 'tcp_keepalive' panicked at 'assertion failed: `(left == right)`
  left: `75s`,
 right: `30s`', tests/socket.rs:727:5
```