### PR TITLE
Implement bind_device for Apple devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.86"
+libc = "0.2.95"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "ws2ipdef", "ws2tcpip"] }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -779,6 +779,42 @@ fn device() {
     panic!("failed to bind to any device.");
 }
 
+#[cfg(all(feature = "all", target_vendor = "apple"))]
+#[test]
+fn device() {
+    // Some common network interface on macOS.
+    const INTERFACES: &[&str] = &["lo\0", "lo0\0", "en0\0"];
+
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    assert_eq!(socket.device_index().unwrap(), None);
+
+    for interface in INTERFACES.iter() {
+        let iface_index = std::num::NonZeroU32::new(unsafe {
+            libc::if_nametoindex(interface.as_ptr() as *const _)
+        });
+        // If no index is returned, try another interface alias
+        if iface_index.is_none() {
+            continue;
+        }
+        if let Err(err) = socket.bind_device_by_index(iface_index) {
+            // Network interface is not available try another.
+            if matches!(err.raw_os_error(), Some(libc::ENODEV)) {
+                eprintln!("error binding to device (`{}`): {}", interface, err);
+                continue;
+            } else {
+                panic!("unexpected error binding device: {}", err);
+            }
+        }
+        assert_eq!(socket.device_index().unwrap(), iface_index);
+
+        socket.bind_device_by_index(None).unwrap();
+        assert_eq!(socket.device_index().unwrap(), None);
+        // Just need to do it with one interface.
+        return;
+    }
+
+    panic!("failed to bind to any device.");
+}
 #[cfg(all(
     feature = "all",
     any(


### PR DESCRIPTION
I've implemented `bind_device` for Apple devices (macOS and iOS), but I've only tested this on macOS. I've tried to maintain a similar interface as on the other platforms, as far as using an interface alias goes. The issue with that is the alias needs to be a null terminated string to resolve the interface index.  These changes depend on [`IP_BOUND_IF`](https://github.com/rust-lang/libc/pull/2168) being added to `libc`, hence this is a draft PR - this provides for ample time to discuss if `bind_device` on macOS should take an interface index as a parameter rather than an alias. 