### PR TITLE
Document some unsafety

### DIFF
--- a/src/sockref.rs
+++ b/src/sockref.rs
@@ -26,6 +26,8 @@ use crate::Socket;
 ///
 /// # Examples
 ///
+/// Below is an example of converting a [`TcpStream`] into a [`SockRef`].
+///
 /// ```
 /// use std::net::{TcpStream, SocketAddr};
 ///
@@ -56,6 +58,29 @@ use crate::Socket;
 /// # handle.join().unwrap();
 /// # Ok(())
 /// # }
+/// ```
+///
+/// Below is an example of **incorrect usage** of `SockRef::from`, which is
+/// currently possible (but not intended and will be fixed in future versions).
+///
+/// ```compile_fail
+/// use socket2::SockRef;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// /// THIS USAGE IS NOT VALID!
+/// let socket_ref = SockRef::from(&123);
+/// // The above line is overseen possibility when using `SockRef::from`, it
+/// // uses the `RawFd` (on Unix), which is a type alias for `c_int`/`i32`,
+/// // which implements `AsRawFd`. However it may be clear that this usage is
+/// // invalid as it doesn't guarantee that `123` is a valid file descriptor.
+///
+/// // Using `Socket::set_nodelay` now will call it on a file descriptor we
+/// // don't own! We don't even not if the file descriptor is valid or a socket.
+/// socket_ref.set_nodelay(true)?;
+/// drop(socket_ref);
+/// # Ok(())
+/// # }
+/// # DO_NOT_COMPILE
 /// ```
 pub struct SockRef<'s> {
     /// Because this is a reference we don't own the `Socket`, however `Socket`

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -524,8 +524,8 @@ impl SockAddr {
 
 pub(crate) type Socket = c_int;
 
-pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
-    unsafe { crate::socket::Inner::from_raw_fd(socket) }
+pub(crate) unsafe fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
+    crate::socket::Inner::from_raw_fd(socket)
 }
 
 pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -191,8 +191,8 @@ fn init() {
 
 pub(crate) type Socket = sock::SOCKET;
 
-pub(crate) fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
-    unsafe { crate::socket::Inner::from_raw_socket(socket as RawSocket) }
+pub(crate) unsafe fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
+    crate::socket::Inner::from_raw_socket(socket as RawSocket)
 }
 
 pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -125,6 +125,14 @@ fn protocol_fmt_debug() {
 }
 
 #[test]
+#[should_panic = "tried to create a `Socket` with an invalid fd"]
+#[cfg(unix)]
+fn from_invalid_raw_fd_should_panic() {
+    use std::os::unix::io::FromRawFd;
+    let _socket = unsafe { Socket::from_raw_fd(-1) };
+}
+
+#[test]
 #[cfg(all(unix, feature = "all"))]
 fn socket_address_unix() {
     let string = "/tmp/socket";


### PR DESCRIPTION
This documents some internal (un)safety around the internal `Socket::from_raw` function.

And adds an example of incorrect usage of `SockRef::from` as highlighted by #229 and #218.

Updates #229.
Updates #218.