### PR TITLE
Support TCP_USER_TIMEOUT socket option for various unix-likes

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1605,13 +1605,25 @@ impl crate::Socket {
     /// corresponding connection.
     #[cfg(all(
         feature = "all",
-        any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+        any(
+            target_os = "android",
+            target_os = "emscripten",
+            target_os = "fuchsia",
+            target_os = "l4re",
+            target_os = "linux",
+        )
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+            any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "l4re",
+                target_os = "linux",
+            )
         )))
     )]
     pub fn set_tcp_user_timeout(&self, duration: Option<Duration>) -> io::Result<()> {
@@ -1639,13 +1651,25 @@ impl crate::Socket {
     /// [`set_tcp_user_timeout`]: Socket::set_tcp_user_timeout
     #[cfg(all(
         feature = "all",
-        any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+        any(
+            target_os = "android",
+            target_os = "emscripten",
+            target_os = "fuchsia",
+            target_os = "l4re",
+            target_os = "linux",
+        )
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+            any(
+                target_os = "android",
+                target_os = "emscripten",
+                target_os = "fuchsia",
+                target_os = "l4re",
+                target_os = "linux",
+            )
         )))
     )]
     pub fn tcp_user_timeout(&self) -> io::Result<Option<Duration>> {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1605,25 +1605,13 @@ impl crate::Socket {
     /// corresponding connection.
     #[cfg(all(
         feature = "all",
-        any(
-            target_os = "android",
-            target_os = "emscripten",
-            target_os = "fuchsia",
-            target_os = "l4re",
-            target_os = "linux",
-        )
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "l4re",
-                target_os = "linux",
-            )
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
         )))
     )]
     pub fn set_tcp_user_timeout(&self, duration: Option<Duration>) -> io::Result<()> {
@@ -1651,25 +1639,13 @@ impl crate::Socket {
     /// [`set_tcp_user_timeout`]: Socket::set_tcp_user_timeout
     #[cfg(all(
         feature = "all",
-        any(
-            target_os = "android",
-            target_os = "emscripten",
-            target_os = "fuchsia",
-            target_os = "l4re",
-            target_os = "linux",
-        )
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(
-                target_os = "android",
-                target_os = "emscripten",
-                target_os = "fuchsia",
-                target_os = "l4re",
-                target_os = "linux",
-            )
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
         )))
     )]
     pub fn tcp_user_timeout(&self) -> io::Result<Option<Duration>> {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1603,10 +1603,16 @@ impl crate::Socket {
     /// If set, this specifies the maximum amount of time that transmitted data may remain
     /// unacknowledged or buffered data may remain untransmitted before TCP will forcibly close the
     /// corresponding connection.
-    #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+    ))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "all", any(target_os = "linux", target_os = "android"))))
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+        )))
     )]
     pub fn set_tcp_user_timeout(&self, duration: Option<Duration>) -> io::Result<()> {
         use std::convert::TryInto;
@@ -1631,10 +1637,16 @@ impl crate::Socket {
     /// For more information about this option, see [`set_tcp_user_timeout`].
     ///
     /// [`set_tcp_user_timeout`]: Socket::set_tcp_user_timeout
-    #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+    ))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "all", any(target_os = "linux", target_os = "android"))))
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+        )))
     )]
     pub fn tcp_user_timeout(&self) -> io::Result<Option<Duration>> {
         unsafe {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1139,3 +1139,9 @@ test!(IPv6 only_v6, set_only_v6(true));
 // IPv6 socket are already IPv6 only on FreeBSD and Windows.
 #[cfg(any(windows, target_os = "freebsd"))]
 test!(IPv6 only_v6, set_only_v6(false));
+
+#[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
+test!(
+    tcp_user_timeout,
+    set_tcp_user_timeout(Some(Duration::from_secs(10)))
+);

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1140,7 +1140,10 @@ test!(IPv6 only_v6, set_only_v6(true));
 #[cfg(any(windows, target_os = "freebsd"))]
 test!(IPv6 only_v6, set_only_v6(false));
 
-#[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
+#[cfg(all(
+    feature = "all",
+    any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+))]
 test!(
     tcp_user_timeout,
     set_tcp_user_timeout(Some(Duration::from_secs(10)))

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1142,13 +1142,7 @@ test!(IPv6 only_v6, set_only_v6(false));
 
 #[cfg(all(
     feature = "all",
-    any(
-        target_os = "android",
-        target_os = "emscripten",
-        target_os = "fuchsia",
-        target_os = "l4re",
-        target_os = "linux",
-    )
+    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
 ))]
 test!(
     tcp_user_timeout,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1142,7 +1142,13 @@ test!(IPv6 only_v6, set_only_v6(false));
 
 #[cfg(all(
     feature = "all",
-    any(target_os = "linux", target_os = "android", target_os = "fuchsia")
+    any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "l4re",
+        target_os = "linux",
+    )
 ))]
 test!(
     tcp_user_timeout,


### PR DESCRIPTION
TCP_USER_TIMEOUT allows the user to configure tcp connections to close if the data sits in buffers without getting sent for some user specified time. It's another angle at resolving stuck tcp connections.

I've enabled this for ~all~ most targets that libc::TCP_USER_TIMEOUT exists for (linux, android, ~l4re, emscripten,~ fuschia), but I've only tested it on linux