### PR TITLE
Fix size check for abstract namespaces in SockAddr::unix

### DIFF
--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -139,6 +139,14 @@ fn socket_address_unix() {
     let addr = SockAddr::unix(string).unwrap();
     assert!(addr.as_socket_ipv4().is_none());
     assert!(addr.as_socket_ipv6().is_none());
+    if cfg!(any(target_os = "linux", target_os = "android")) {
+        let path = "\0h".repeat(108 / 2);
+        let addr = SockAddr::unix(path).unwrap();
+        assert_eq!(
+            addr.len() as usize,
+            std::mem::size_of::<libc::sockaddr_un>()
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Not sure whether passing abstract namespaces to `unix()` is totally supported, but there is the check below for whether to add another byte to sockaddr_len for the null terminator, which doesn't if the path starts with a null byte.
