### PR TITLE
Add recv_from_into_buf()

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -493,6 +493,15 @@ impl Socket {
         self.recv_from_with_flags(buf, 0)
     }
 
+    /// Receives data from the socket. On success, returns the number of bytes
+    /// read and the address from whence the data came.
+    ///
+    /// Similar to [`recv_from`] except using a `&mut [u8]` initialised buffer.
+    pub fn recv_from_into_buf(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
+        let buf = unsafe { &mut *(buf as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        self.recv_from(buf)
+    }
+
     /// Identical to [`recv_from`] but allows for specification of arbitrary
     /// flags to the underlying `recvfrom` call.
     ///


### PR DESCRIPTION
It would be nice to have a way to use `recv_from` without needing `MaybeUninit`, even if it's a little less efficient.

The code is trivial, IMO the hard part is coming up with a clear name for this method in comparison to `recv_from`. Any better options?

fixes #223