### PR TITLE
 Windows: Add support for Unix sockets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ add new tests.
 
 All types and methods that are available on all tier 1 platforms are defined in
 the first level of the source, i.e. `src/*.rs` files. Additional API that is
-platform specific, e.g. `Domain::UNIX`, is defined in `src/sys/*.rs` and only
+platform specific, e.g. `Domain::VSOCK`, is defined in `src/sys/*.rs` and only
 for the platforms that support it. For API that is not available on all tier 1
 platforms the `all` feature is used, to indicate to the user that they're using
 API that might is not available on all platforms.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,9 @@ impl Domain {
     /// Domain for IPv6 communication, corresponding to `AF_INET6`.
     pub const IPV6: Domain = Domain(sys::AF_INET6);
 
+    /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
+    pub const UNIX: Domain = Domain(sys::AF_UNIX);
+
     /// Returns the correct domain for `address`.
     pub const fn for_address(address: SocketAddr) -> Domain {
         match address {

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -1,5 +1,6 @@
 use std::mem::{self, size_of, MaybeUninit};
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::path::Path;
 use std::{fmt, io};
 
 #[cfg(windows)]
@@ -209,6 +210,16 @@ impl SockAddr {
             Some(SocketAddr::V6(addr)) => Some(addr),
             _ => None,
         }
+    }
+
+    /// Constructs a `SockAddr` with the family `AF_UNIX` and the provided path.
+    ///
+    /// Returns an error if the path is longer than `SUN_LEN`.
+    pub fn unix<P>(path: P) -> io::Result<SockAddr>
+    where
+        P: AsRef<Path>,
+    {
+        crate::sys::unix_sockaddr(path.as_ref())
     }
 }
 


### PR DESCRIPTION
Newer versions of Windows support AF_UNIX stream sockets. This change
adds Windows support for the `SockAddr::unix` function and the
`Domain::UNIX` constant.

Since Unix sockets are now available on all tier1 platforms, this also
removes `all` feature requirement from the `SockAddr::unix` function.