### PR TITLE
Assert validity on the raw socket in SockRef::from

### DIFF
--- a/src/sockref.rs
+++ b/src/sockref.rs
@@ -145,11 +145,3 @@ impl fmt::Debug for SockRef<'_> {
             .finish()
     }
 }
-
-#[test]
-#[should_panic]
-#[cfg(unix)]
-fn sockref_from_invalid_fd() {
-    let raw: std::os::unix::io::RawFd = -1;
-    let _ = SockRef::from(&raw);
-}


### PR DESCRIPTION
Since we now use the niche feature on Unix it's unsound to use
SockRef::from(-1), but it can be done without any unsafe. This change
adds an assertion to ensure we hit this soundness issue.

Still need to wait on the I/O safety RFC:
https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
Tracking issue: https://github.com/rust-lang/rust/issues/87074
Implementation pr: https://github.com/rust-lang/rust/pull/87329

Closes #229 (again)
Updates #218
Closes #244