### PR TITLE
Fix compilation on Haiku and OpenBSD with --features all

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1404,11 +1404,22 @@ impl Socket {
 impl Socket {
     /// Get the value of the `TCP_KEEPIDLE` option on this socket.
     ///
-    /// This returns the value of `SO_KEEPALIVE` on OpenBSD and Haiku,
-    /// `TCP_KEEPALIVE` on macOS and iOS, and `TCP_KEEPIDLE` on all other Unix
-    /// operating systems.
-    #[cfg(any(doc, all(feature = "all", not(windows))))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", not(windows)))))]
+    /// This returns the value of `TCP_KEEPALIVE` on macOS and iOS and `TCP_KEEPIDLE` on all other
+    /// supported Unix operating systems.
+    #[cfg(any(
+        doc,
+        all(
+            feature = "all",
+            not(any(windows, target_os = "haiku", target_os = "openbsd"))
+        )
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            not(any(windows, target_os = "haiku", target_os = "openbsd"))
+        )))
+    )]
     pub fn keepalive_time(&self) -> io::Result<Duration> {
         sys::keepalive_time(self.as_raw())
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -866,6 +866,7 @@ fn into_timeval(duration: Option<Duration>) -> libc::timeval {
 }
 
 #[cfg(feature = "all")]
+#[cfg(not(any(target_os = "haiku", target_os = "openbsd")))]
 pub(crate) fn keepalive_time(fd: Socket) -> io::Result<Duration> {
     unsafe {
         getsockopt::<c_int>(fd, IPPROTO_TCP, KEEPALIVE_TIME)

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -729,7 +729,10 @@ fn tcp_keepalive() {
     // Set the parameters.
     socket.set_tcp_keepalive(&params).unwrap();
 
-    #[cfg(all(feature = "all", not(windows)))]
+    #[cfg(all(
+        feature = "all",
+        not(any(windows, target_os = "haiku", target_os = "openbsd"))
+    ))]
     assert_eq!(socket.keepalive_time().unwrap(), Duration::from_secs(200));
 
     #[cfg(all(


### PR DESCRIPTION
`keepalive_time()` is not available on these platforms

Fixes #255 