### PR TITLE
Use correct socket option level and name to get/set freebind flag

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1478,8 +1478,8 @@ impl crate::Socket {
     )]
     pub fn freebind(&self) -> io::Result<bool> {
         unsafe {
-            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::IP_FREEBIND)
-                .map(|reuse| reuse != 0)
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_IP, libc::IP_FREEBIND)
+                .map(|freebind| freebind != 0)
         }
     }
 
@@ -1501,13 +1501,13 @@ impl crate::Socket {
             any(target_os = "android", target_os = "fuchsia", target_os = "linux")
         )))
     )]
-    pub fn set_freebind(&self, reuse: bool) -> io::Result<()> {
+    pub fn set_freebind(&self, freebind: bool) -> io::Result<()> {
         unsafe {
             setsockopt(
                 self.as_raw(),
-                libc::SOL_SOCKET,
+                libc::SOL_IP,
                 libc::IP_FREEBIND,
-                reuse as c_int,
+                freebind as c_int,
             )
         }
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1512,6 +1512,71 @@ impl crate::Socket {
         }
     }
 
+    /// Get the value of the `IPV6_FREEBIND` option on this socket.
+    ///
+    /// This is an IPv6 counterpart of `IP_FREEBIND` socket option on
+    /// Android/Linux. For more information about this option, see
+    /// [`set_freebind`].
+    ///
+    /// [`set_freebind`]: crate::Socket::set_freebind
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub fn freebind_ipv6(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_IPV6, libc::IPV6_FREEBIND)
+                .map(|freebind| freebind != 0)
+        }
+    }
+
+    /// Set value for the `IPV6_FREEBIND` option on this socket.
+    ///
+    /// This is an IPv6 counterpart of `IP_FREEBIND` socket option on
+    /// Android/Linux. For more information about this option, see
+    /// [`set_freebind`].
+    ///
+    /// [`set_freebind`]: crate::Socket::set_freebind
+    ///
+    /// # Examples
+    ///
+    /// On Linux:
+    ///
+    /// ```
+    /// use socket2::{Domain, Socket, Type};
+    /// use std::io::{self, Error, ErrorKind};
+    ///
+    /// fn enable_freebind(socket: &Socket) -> io::Result<()> {
+    ///     match socket.domain()? {
+    ///         Domain::IPV4 => socket.set_freebind(true)?,
+    ///         Domain::IPV6 => socket.set_freebind_ipv6(true)?,
+    ///         _ => return Err(Error::new(ErrorKind::Other, "unsupported domain")),
+    ///     };
+    ///     Ok(())
+    /// }
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// #     let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+    /// #     enable_freebind(&socket)
+    /// # }
+    /// ```
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub fn set_freebind_ipv6(&self, freebind: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                libc::SOL_IPV6,
+                libc::IPV6_FREEBIND,
+                freebind as c_int,
+            )
+        }
+    }
+
     /// Copies data between a `file` and this socket using the `sendfile(2)`
     /// system call. Because this copying is done within the kernel,
     /// `sendfile()` is more efficient than the combination of `read(2)` and

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1144,6 +1144,8 @@ test!(
 test!(keepalive, set_keepalive(true));
 #[cfg(all(feature = "all", any(target_os = "fuchsia", target_os = "linux")))]
 test!(freebind, set_freebind(true));
+#[cfg(all(feature = "all", any(target_os = "linux")))]
+test!(IPv6 freebind_ipv6, set_freebind_ipv6(true));
 
 test!(IPv4 ttl, set_ttl(40));
 


### PR DESCRIPTION
`freebind()`/`set_freebind()` are currently getting/setting the reuseport flag because we are passing an incorrect socket level - `SOL_SOCKET` instead of `SOL_IP`, and `SO_REUSEPORT` happens to have the same value as `IP_FREEBIND` on Linux:
```
  $ git -C ~/src/linux grep -h 'define \(SO_REUSEPORT\|IP_FREEBIND\)' -- include/uapi
  #define SO_REUSEPORT    15
  #define IP_FREEBIND     15
```
Fix it by using `(SOL_IP, IP_FREEBIND)` and `(SOL_IPV6, IPV6_FREEBIND)` socket option (level, name) to get/set the freebind flag, for INET and INET6 sockets, respectively.

Alternatively, `(SOL_IP, IP_FREEBIND)` could be used for both IPv4 and IPv6 because Linux kernel underneath toggles a flag that is shared by v4 and v6 network stack. However, this is an implementation detail, and arguably not what would be expected by the user when looking at strace output.

Fixes #257.