### PR TITLE
Example doc comment: fix usage of socket.set_only_v6()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@
 //! // Create a TCP listener bound to two addresses.
 //! let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
 //!
+//! socket.set_only_v6(false)?;
 //! let address: SocketAddr = "[::1]:12345".parse().unwrap();
 //! socket.bind(&address.into())?;
-//! socket.set_only_v6(false)?;
 //! socket.listen(128)?;
 //!
 //! let listener: TcpListener = socket.into();


### PR DESCRIPTION
The call to `socket.set_only_v6()` needs to be *before* the call to
`socket.bind()`.

This is for issue #259.