### PR TITLE
Add compile_error! for unsupported targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,9 @@ mod sys;
 #[path = "sys/windows.rs"]
 mod sys;
 
+#[cfg(not(any(windows, unix)))]
+compile_error!("Socket2 doesn't support the compile target");
+
 use sys::c_int;
 
 pub use sockaddr::SockAddr;


### PR DESCRIPTION
Although it still spits out a bunch of errors at least the first one
will be informative about the root cause.

https://github.com/rust-lang/rust/issues/68838 tracks a version that
suppresses subsequent errors.

/cc @twitchax not a huge improvement, but still an improvement.