### PR TITLE
Add support to bind socket to FIB on a FreeBSD

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1350,16 +1350,16 @@ impl crate::Socket {
 
     /// Sets the value for the `SO_SETFIB` option on this socket.
     ///
-    /// Bind socket to the specified forwarding table (VRF) on a *BSD OS
+    /// Bind socket to the specified forwarding table (VRF) on a FreeBSD.
     #[cfg(all(
         feature = "all",
-        any(target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")
+        any(target_os = "freebsd")
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")
+            any(target_os = "freebsd")
         )))
     )]
     pub fn set_fib(&self, fib: u32) -> io::Result<()> {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1348,6 +1348,31 @@ impl crate::Socket {
         .map(|_| ())
     }
 
+    /// Sets the value for the `SO_SETFIB` option on this socket.
+    ///
+    /// Bind socket to the specified forwarding table (VRF) on a *BSD OS
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd")
+        )))
+    )]
+    pub fn set_fib(&self, fib: u32) -> io::Result<()> {
+        syscall!(setsockopt(
+            self.as_raw(),
+            libc::SOL_SOCKET,
+            libc::SO_SETFIB,
+            (&fib as *const u32).cast(),
+            mem::size_of::<u32>() as libc::socklen_t,
+        ))
+        .map(|_| ())
+    }
+
     /// Sets the value for `IP_BOUND_IF` option on this socket.
     ///
     /// If a socket is bound to an interface, only packets received from that

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1353,13 +1353,13 @@ impl crate::Socket {
     /// Bind socket to the specified forwarding table (VRF) on a *BSD OS
     #[cfg(all(
         feature = "all",
-        any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd")
+        any(target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(
             feature = "all",
-            any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd")
+            any(target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")
         )))
     )]
     pub fn set_fib(&self, fib: u32) -> io::Result<()> {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1351,17 +1351,8 @@ impl crate::Socket {
     /// Sets the value for the `SO_SETFIB` option on this socket.
     ///
     /// Bind socket to the specified forwarding table (VRF) on a FreeBSD.
-    #[cfg(all(
-        feature = "all",
-        any(target_os = "freebsd")
-    ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(
-            feature = "all",
-            any(target_os = "freebsd")
-        )))
-    )]
+    #[cfg(all(feature = "all", any(target_os = "freebsd")))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", any(target_os = "freebsd")))))]
     pub fn set_fib(&self, fib: u32) -> io::Result<()> {
         syscall!(setsockopt(
             self.as_raw(),


### PR DESCRIPTION
Hi.

This patch simply add support SO_SETFIB option to socket on a FreeBSD+ OS.
It allow to build VRF-aware applications on FreeBSD and partially solve problem with missing Bind-To-Device option on BSD.