### PR TITLE
Add support to attach filter onto socket on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.96"
+libc = "0.2.107"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "ws2ipdef", "ws2tcpip"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,6 @@ compile_error!("Socket2 doesn't support the compile target");
 
 use sys::c_int;
 
-#[cfg(all(feature = "all", target_os = "linux"))]
-pub use sys::SockFilter;
-
 pub use sockaddr::SockAddr;
 pub use socket::Socket;
 pub use sockref::SockRef;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,9 @@ compile_error!("Socket2 doesn't support the compile target");
 
 use sys::c_int;
 
+#[cfg(all(feature = "all", target_os = "linux"))]
+pub use sys::SockFilter;
+
 pub use sockaddr::SockAddr;
 pub use socket::Socket;
 pub use sockref::SockRef;

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1781,10 +1781,10 @@ impl crate::Socket {
     ///
     /// For more information about this option, see [filter](https://www.kernel.org/doc/html/v5.12/networking/filter.html)
     #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
-    pub fn attach_filter(&self, filters: &mut [libc::sock_filter]) -> io::Result<()> {
+    pub fn attach_filter(&self, filters: &[libc::sock_filter]) -> io::Result<()> {
         let prog = libc::sock_fprog {
             len: filters.len() as u16,
-            filter: filters.as_mut_ptr(),
+            filter: filters.as_ptr() as *mut _,
         };
 
         unsafe {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -10,7 +10,9 @@ use std::cmp::min;
 #[cfg(not(target_os = "redox"))]
 use std::io::IoSlice;
 use std::marker::PhantomData;
-use std::mem::{self, forget, size_of, MaybeUninit};
+#[cfg(all(feature = "all", target_os = "linux"))]
+use std::mem::forget;
+use std::mem::{self, size_of, MaybeUninit};
 use std::net::Shutdown;
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(all(feature = "all", target_vendor = "apple"))]
@@ -55,7 +57,10 @@ use libc::{c_void, in6_addr, in_addr};
 use crate::RecvFlags;
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
 
-pub(crate) use libc::{c_int, c_uchar, c_uint, c_ushort};
+#[cfg(all(feature = "all", target_os = "linux"))]
+pub(crate) use libc::{c_uchar, c_uint, c_ushort};
+
+pub(crate) use libc::c_int;
 
 // Used in `Domain`.
 pub(crate) use libc::{AF_INET, AF_INET6};


### PR DESCRIPTION
Hi

This patch add support to attach filter onto socket on Linux.
See also: [Linux Socket Filtering aka Berkeley Packet Filter (BPF)](https://www.kernel.org/doc/html/v5.12/networking/filter.html)