### PR TITLE
Move Send and Sync impl for MaybeUninitSlice to sys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,10 +285,6 @@ impl RecvFlags {
 #[repr(transparent)]
 pub struct MaybeUninitSlice<'a>(sys::MaybeUninitSlice<'a>);
 
-unsafe impl<'a> Send for MaybeUninitSlice<'a> {}
-
-unsafe impl<'a> Sync for MaybeUninitSlice<'a> {}
-
 impl<'a> fmt::Debug for MaybeUninitSlice<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.0.as_slice(), fmt)

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -224,7 +224,7 @@ impl From<SocketAddrV4> for SockAddr {
         let sockaddr_in = sockaddr_in {
             sin_family: AF_INET as sa_family_t,
             sin_port: addr.port().to_be(),
-            sin_addr: crate::sys::to_in_addr(&addr.ip()),
+            sin_addr: crate::sys::to_in_addr(addr.ip()),
             sin_zero: Default::default(),
             #[cfg(any(
                 target_os = "dragonfly",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -414,6 +414,10 @@ pub struct MaybeUninitSlice<'a> {
     _lifetime: PhantomData<&'a mut [MaybeUninit<u8>]>,
 }
 
+unsafe impl<'a> Send for MaybeUninitSlice<'a> {}
+
+unsafe impl<'a> Sync for MaybeUninitSlice<'a> {}
+
 impl<'a> MaybeUninitSlice<'a> {
     pub(crate) fn new(buf: &'a mut [MaybeUninit<u8>]) -> MaybeUninitSlice<'a> {
         MaybeUninitSlice {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -157,6 +157,10 @@ pub struct MaybeUninitSlice<'a> {
     _lifetime: PhantomData<&'a mut [MaybeUninit<u8>]>,
 }
 
+unsafe impl<'a> Send for MaybeUninitSlice<'a> {}
+
+unsafe impl<'a> Sync for MaybeUninitSlice<'a> {}
+
 impl<'a> MaybeUninitSlice<'a> {
     pub fn new(buf: &'a mut [MaybeUninit<u8>]) -> MaybeUninitSlice<'a> {
         assert!(buf.len() <= ULONG::MAX as usize);


### PR DESCRIPTION
Fixes a Clippy warning and also makes it clear how the unsafe
implementation is actually safe.