### PR TITLE
Add support for the socket options TCP_CORK, TCP_QUICKACK and TCP_THIN_LINEAR_TIMEOUTS

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1385,6 +1385,60 @@ impl crate::Socket {
         }
     }
 
+    /// Get the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this socket.
+    ///
+    /// For more information about this option, see [`set_thin_linear_timeouts`].
+    ///
+    /// [`set_thin_linear_timeouts`]: Socket::set_thin_linear_timeouts
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn thin_linear_timeouts(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<Bool>(
+                self.as_raw(),
+                libc::IPPROTO_TCP,
+                libc::TCP_THIN_LINEAR_TIMEOUTS,
+            )
+            .map(|timeouts| timeouts != 0)
+        }
+    }
+
+    /// Set the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this socket.
+    ///    
+    /// If set, the kernel will dynamically detect a thin-stream connection if there are less than four packets in flight.
+    /// With less than four packets in flight the normal TCP fast retransmission will not be effective.
+    /// The kernel will modify the retransmission to avoid the very high latencies that thin stream suffer because of exponential backoff.
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn set_thin_linear_timeouts(&self, timeouts: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                libc::IPPROTO_TCP,
+                libc::TCP_THIN_LINEAR_TIMEOUTS,
+                timeouts as c_int,
+            )
+        }
+    }
+
     /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
     ///
     /// This value gets the socket binded device's interface name.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1283,6 +1283,57 @@ impl crate::Socket {
         }
     }
 
+    /// Get the value of the `TCP_CORK` option on this socket.
+    ///
+    /// For more information about this option, see [`set_cork`].
+    ///
+    /// [`set_cork`]: Socket::set_cork
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn cork(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_CORK)
+                .map(|cork| cork != 0)
+        }
+    }
+
+    /// Set the value of the `TCP_CORK` option on this socket.
+    ///
+    /// If set, don't send out partial frames. All queued partial frames are
+    /// sent when the option is cleared again. There is a 200 millisecond ceiling on
+    /// the time for which output is corked by `TCP_CORK`. If this ceiling is reached,
+    /// then queued data is automatically transmitted.
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn set_cork(&self, cork: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                libc::IPPROTO_TCP,
+                libc::TCP_CORK,
+                cork as c_int,
+            )
+        }
+    }
+
     /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
     ///
     /// This value gets the socket binded device's interface name.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1334,6 +1334,57 @@ impl crate::Socket {
         }
     }
 
+    /// Get the value of the `TCP_QUICKACK` option on this socket.
+    ///
+    /// For more information about this option, see [`set_quickack`].
+    ///
+    /// [`set_quickack`]: Socket::set_quickack
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn quickack(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_QUICKACK)
+                .map(|quickack| quickack != 0)
+        }
+    }
+
+    /// Set the value of the `TCP_QUICKACK` option on this socket.
+    ///
+    /// If set, acks are sent immediately, rather than delayed if needed in accordance to normal
+    /// TCP operation. This flag is not permanent, it only enables a switch to or from quickack mode.
+    /// Subsequent operation of the TCP protocol will once again enter/leave quickack mode depending on
+    /// internal protocol processing and factors such as delayed ack timeouts occurring and data transfer.
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
+    )]
+    pub fn set_quickack(&self, quickack: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                libc::IPPROTO_TCP,
+                libc::TCP_QUICKACK,
+                quickack as c_int,
+            )
+        }
+    }
+
     /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
     ///
     /// This value gets the socket binded device's interface name.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1147,6 +1147,11 @@ test!(cork, set_cork(true));
     any(target_os = "android", target_os = "fuchsia", target_os = "linux")
 ))]
 test!(quickack, set_quickack(false));
+#[cfg(all(
+    feature = "all",
+    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+))]
+test!(thin_linear_timeouts, set_thin_linear_timeouts(true));
 test!(linger, set_linger(Some(Duration::from_secs(10))));
 test!(
     read_timeout,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1142,6 +1142,11 @@ test!(
     any(target_os = "android", target_os = "fuchsia", target_os = "linux")
 ))]
 test!(cork, set_cork(true));
+#[cfg(all(
+    feature = "all",
+    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+))]
+test!(quickack, set_quickack(false));
 test!(linger, set_linger(Some(Duration::from_secs(10))));
 test!(
     read_timeout,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1137,6 +1137,11 @@ test!(
     mark,
     set_mark(123)
 );
+#[cfg(all(
+    feature = "all",
+    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+))]
+test!(cork, set_cork(true));
 test!(linger, set_linger(Some(Duration::from_secs(10))));
 test!(
     read_timeout,


### PR DESCRIPTION
Hi,

this is my first try and I ask for a review. I encounter one problem:

On my system TCP_QUICKACK is enabled by default. So the test fails. I could change the test, so that it deactivates TCP_QUICKACK, but on a different system it might be disabled by default. So that this test is flaky at the moment. 

The test could be changed that it checks if TCP_QUICKACK is enabled or not and then activate/deactivate the flag.

Closes #285 