### PR TITLE
Modernise license format in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
 ]
-license       = "MIT/Apache-2.0"
+license       = "MIT OR Apache-2.0"
 readme        = "README.md"
 repository    = "https://github.com/rust-lang/socket2"
 homepage      = "https://github.com/rust-lang/socket2"


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#slash

> Previously multiple licenses could be separated with a /, but that usage is deprecated.

removes ambiguity about whether AND or OR is intended, I guess.