### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 0.4.3
+# 0.4.4
+
+## Fixed
+
+* Libc v0.2.114 fixed an issue where `ip_mreqn` where was not defined for Linux
+  s390x.
+
+# 0.4.3 (yanked)
 
 ## Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "socket2"
-version       = "0.4.3"
+version       = "0.4.4"
 authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.113"
+libc = "0.2.114"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "ws2ipdef", "ws2tcpip"] }


### PR DESCRIPTION
And update to libc v0.2.114 to fix https://github.com/rust-lang/socket2/pull/284#issuecomment-1019242025.