### PR TITLE
Fix OpenBSD build

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1164,6 +1164,7 @@ impl Socket {
         target_os = "haiku",
         target_os = "illumos",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
     )))]

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1135,6 +1135,7 @@ impl Socket {
         target_os = "haiku",
         target_os = "illumos",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
     )))]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1004,6 +1004,7 @@ pub(crate) fn from_in6_addr(addr: in6_addr) -> Ipv6Addr {
     target_os = "haiku",
     target_os = "illumos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
 )))]


### PR DESCRIPTION
Rust libc does not provide ip_mreqn for openbsd, so add it to the cfg exclusion sets where necessary.