### PR TITLE
Add Socket::new_nonblocking

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -138,6 +138,38 @@ impl Socket {
         sys::socket(domain.0, ty.0, protocol).map(Socket::from_raw)
     }
 
+    /// Creates a new socket in nonblocking mode.
+    pub fn new_nonblocking(
+        domain: Domain,
+        ty: Type,
+        protocol: Option<Protocol>,
+    ) -> io::Result<Socket> {
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        let ty = ty._nonblocking();
+        let socket = Socket::new(domain, ty, protocol)?;
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))]
+        socket.set_nonblocking(true)?;
+        Ok(socket)
+    }
+
     /// Creates a pair of sockets which are connected to each other.
     ///
     /// This function corresponds to `socketpair(2)`.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -281,6 +281,20 @@ impl Type {
         )))
     )]
     pub const fn nonblocking(self) -> Type {
+        self._nonblocking()
+    }
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    pub(crate) const fn _nonblocking(self) -> Type {
         Type(self.0 | libc::SOCK_NONBLOCK)
     }
 
@@ -1439,7 +1453,7 @@ impl crate::Socket {
     }
 
     /// Set the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this socket.
-    ///    
+    ///
     /// If set, the kernel will dynamically detect a thin-stream connection if there are less than four packets in flight.
     /// With less than four packets in flight the normal TCP fast retransmission will not be effective.
     /// The kernel will modify the retransmission to avoid the very high latencies that thin stream suffer because of exponential backoff.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -174,6 +174,12 @@ fn set_nonblocking() {
     assert_nonblocking(&socket, false);
 }
 
+#[test]
+fn new_nonblocking() {
+    let socket = Socket::new_nonblocking(Domain::IPV4, Type::STREAM, None).unwrap();
+    assert_nonblocking(&socket, true);
+}
+
 fn assert_common_flags(socket: &Socket, expected: bool) {
     #[cfg(unix)]
     assert_close_on_exec(socket, expected);


### PR DESCRIPTION
Equivalent to:

```rs
#[cfg(any(
    target_os = "android",
    target_os = "dragonfly",
    target_os = "freebsd",
    target_os = "fuchsia",
    target_os = "illumos",
    target_os = "linux",
    target_os = "netbsd",
    target_os = "openbsd"
))]
let ty = ty.nonblocking();

let socket = Socket::new(domain, ty, protocol)?;

#[cfg(not(any(
    target_os = "android",
    target_os = "dragonfly",
    target_os = "freebsd",
    target_os = "fuchsia",
    target_os = "illumos",
    target_os = "linux",
    target_os = "netbsd",
    target_os = "openbsd"
)))]
socket.set_nonblocking(true)?;
```

I've seen code like this several times and thought it would be useful to have a constructor that does the same thing.
