### PR TITLE
Relax windows-sys dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = ["all"]
 libc = "0.2.124"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "=0.36"
+version = "0.36"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",


### PR DESCRIPTION
Is setting equals 0.36 exactly necessary here?