### PR TITLE
Disable RECVTOS on OpenBSD

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1398,6 +1398,7 @@ impl Socket {
         target_os = "fuschia",
         target_os = "illumos",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
     )))]
@@ -1423,6 +1424,7 @@ impl Socket {
         target_os = "fuschia",
         target_os = "illumos",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
     )))]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -81,6 +81,7 @@ pub(crate) use libc::IP_HDRINCL;
     target_os = "fuschia",
     target_os = "illumos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
 )))]


### PR DESCRIPTION
The 0.4.5 has a regression that fails building on OpenBSD. From what I can tell `libc::IP_RECVTOS` isn't exported on OpenBSD. This looks like a similar problem in https://github.com/rust-lang/socket2/pull/291

I don't run OpenBSD but I've spotted this issue on a [youtube stream where the streamer was trying to install Helix](https://youtu.be/JGDPV4Wogyg?t=11168).

Could you cut a `0.4.6` release with this patch?