### PR TITLE
Clone trait for SockAddr

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -1,6 +1,6 @@
 use std::mem::{self, size_of, MaybeUninit};
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::{clone, fmt, io};
+use std::{fmt, io};
 
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::SOCKADDR_IN6_0;
@@ -14,7 +14,7 @@ use crate::sys::{
 ///
 /// `SockAddr`s may be constructed directly to and from the standard library
 /// [`SocketAddr`], [`SocketAddrV4`], and [`SocketAddrV6`] types.
-#[derive(clone::Clone)]
+#[derive(Clone)]
 pub struct SockAddr {
     storage: sockaddr_storage,
     len: socklen_t,

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -14,6 +14,7 @@ use crate::sys::{
 ///
 /// `SockAddr`s may be constructed directly to and from the standard library
 /// [`SocketAddr`], [`SocketAddrV4`], and [`SocketAddrV6`] types.
+#[derive(clone::Clone)]
 pub struct SockAddr {
     storage: sockaddr_storage,
     len: socklen_t,
@@ -302,15 +303,6 @@ impl fmt::Debug for SockAddr {
         f.field("ss_family", &self.storage.ss_family)
             .field("len", &self.len)
             .finish()
-    }
-}
-
-impl clone::Clone for SockAddr {
-    fn clone(&self) -> Self {
-        SockAddr {
-            storage: self.storage.clone(),
-            len: self.len,
-        }
     }
 }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -1,6 +1,6 @@
 use std::mem::{self, size_of, MaybeUninit};
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::{fmt, io};
+use std::{clone, fmt, io};
 
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::SOCKADDR_IN6_0;
@@ -302,6 +302,15 @@ impl fmt::Debug for SockAddr {
         f.field("ss_family", &self.storage.ss_family)
             .field("len", &self.len)
             .finish()
+    }
+}
+
+impl clone::Clone for SockAddr {
+    fn clone(&self) -> Self {
+        SockAddr {
+            storage: self.storage.clone(),
+            len: self.len
+        }
     }
 }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -309,7 +309,7 @@ impl clone::Clone for SockAddr {
     fn clone(&self) -> Self {
         SockAddr {
             storage: self.storage.clone(),
-            len: self.len
+            len: self.len,
         }
     }
 }


### PR DESCRIPTION
Fix for #310 - adds the `Clone` trait to `SockAddr` to address certain use cases.