### PR TITLE
Start development of v0.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [stable, 1.46.0, beta, nightly, macos, windows]
+        build: [stable, 1.63.0, beta, nightly, macos, windows]
         include:
           - build: stable
             os: ubuntu-latest
             rust: stable
-          - build: 1.46.0
+          - build: 1.63.0
             os: ubuntu-latest
-            rust: 1.46.0
+            rust: 1.63.0
           - build: beta
             os: ubuntu-latest
             rust: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name          = "socket2"
-version       = "0.4.5"
+version       = "0.5.0"
+publish       = false
 authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ feature flag.
 
 # Minimum Supported Rust Version (MSRV)
 
-Socket2 uses 1.46.0 as MSRV.
+Socket2 uses 1.63.0 as MSRV.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ See the [API documentation] for more.
 
 [API documentation]: https://docs.rs/socket2
 
-# Two branches
+# Branches
 
 Currently Socket2 supports two versions: v0.4 and v0.3. Version 0.4 is developed
-in the master branch, version 0.3 in the [v0.3.x branch].
+in the [v0.4.x branch] branch, version 0.3 in the [v0.3.x branch]. Version 0.5
+is currently being developed in the master branch.
 
 [v0.3.x branch]: https://github.com/rust-lang/socket2/tree/v0.3.x
+[v0.4.x branch]: https://github.com/rust-lang/socket2/tree/v0.4.x
 
 # OS support
 


### PR DESCRIPTION
Also update MSRV to 1.62. In the future we'll switch to 1.63 so we can use the I/O safety feature stabilised in 1.63: https://github.com/rust-lang/rust/pull/95118.

I've also created the v0.4.x branch for backports.