### PR TITLE
Use pre-built cargo-hack in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - name: Install cargo-hack
-      run: cargo install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
     - name: Run tests
       run: cargo hack test --feature-powerset && cargo hack test --feature-powerset --release
 
@@ -68,10 +68,10 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
     - name: Install Target
       run: rustup target add ${{ matrix.target }}
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
     - name: Run check
       run: cargo hack check --feature-powerset --all-targets --examples --bins --tests --target ${{ matrix.target }}
 
@@ -87,9 +87,9 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust nightly
       run: rustup update nightly && rustup default nightly
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
     - name: Install Target
       run: rustup target add ${{ matrix.target }}
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
     - name: Run check
       run: cargo hack check --feature-powerset --all-targets --examples --bins --tests --target ${{ matrix.target }}


### PR DESCRIPTION
Use pre-built cargo-hack in CI
    
The authors of cargo-hack provide an Action to use in CI and avoid having to build from source.
Currently the MSRV CI job fails because latest cargo-hack requires 1.56 to build while the test is
run with 1.46.
Simply running cargo-hack only requies 1.26 though.
    
This should also speedup CI runs, since we don't have to build cargo-hack each time.