### PR TITLE
Implement I/O-safe traits on Socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,3 @@ features = [
 [features]
 # Enable all API, even ones not available on all OSs.
 all = []
-# Use I/O safe traits (requires Rust 1.63.0)
-io_safety = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,5 @@ features = [
 [features]
 # Enable all API, even ones not available on all OSs.
 all = []
+# Use I/O safe traits (requires Rust 1.63.0)
+io_safety = []

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -37,9 +37,7 @@ use std::os::unix::ffi::OsStrExt;
     )
 ))]
 use std::os::unix::io::RawFd;
-#[cfg(feature = "io_safety")]
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 #[cfg(feature = "all")]
 use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 #[cfg(feature = "all")]
@@ -2033,8 +2031,7 @@ impl FromRawFd for crate::Socket {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(all(feature = "io_safety", unix))))]
-#[cfg(feature = "io_safety")]
+#[cfg_attr(docsrs, doc(cfg(unix)))]
 impl AsFd for crate::Socket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: lifetime is bound by "self"
@@ -2042,16 +2039,14 @@ impl AsFd for crate::Socket {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(all(feature = "io_safety", unix))))]
-#[cfg(feature = "io_safety")]
+#[cfg_attr(docsrs, doc(cfg(unix)))]
 impl From<OwnedFd> for crate::Socket {
     fn from(fd: OwnedFd) -> Self {
         Self::from_raw(fd.into_raw_fd())
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(all(feature = "io_safety", unix))))]
-#[cfg(feature = "io_safety")]
+#[cfg_attr(docsrs, doc(cfg(unix)))]
 impl From<crate::Socket> for OwnedFd {
     fn from(sock: crate::Socket) -> Self {
         // SAFETY: sock.into_raw() is a valid fd

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -11,9 +11,9 @@ use std::io::{self, IoSlice};
 use std::marker::PhantomData;
 use std::mem::{self, size_of, MaybeUninit};
 use std::net::{self, Ipv4Addr, Ipv6Addr, Shutdown};
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
-#[cfg(feature = "io_safety")]
-use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
+use std::os::windows::io::{
+    AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,
+};
 use std::sync::Once;
 use std::time::{Duration, Instant};
 use std::{process, ptr, slice};
@@ -820,7 +820,6 @@ impl FromRawSocket for crate::Socket {
     }
 }
 
-#[cfg(feature = "io_safety")]
 impl AsSocket for crate::Socket {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         // SAFETY: lifetime is bound by "self"
@@ -828,14 +827,12 @@ impl AsSocket for crate::Socket {
     }
 }
 
-#[cfg(feature = "io_safety")]
 impl From<OwnedSocket> for crate::Socket {
     fn from(fd: OwnedSocket) -> Self {
         Self::from_raw(fd.into_raw_socket() as Socket)
     }
 }
 
-#[cfg(feature = "io_safety")]
 impl From<crate::Socket> for OwnedSocket {
     fn from(sock: crate::Socket) -> Self {
         // SAFETY: sock.into_raw() is a valid fd


### PR DESCRIPTION
This PR adds a new feature, `io_safety`, which requires Rust 1.63. This feature implements `AsFd`/`AsSocket` on `Socket`, as well as `From<OwnedFd/OwnedSocket>` and `Into<OwnedFd/OwnedSocket>`.

See also: sunfishcode/io-lifetimes#38