### PR TITLE
Implement the I/O-safety traits for Socket and SockRef

### DIFF
--- a/src/sockref.rs
+++ b/src/sockref.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsFd, AsRawFd, FromRawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket};
+use std::os::windows::io::{AsRawSocket, AsSocket, FromRawSocket};
 
 use crate::Socket;
 
@@ -15,14 +15,13 @@ use crate::Socket;
 /// This allows for example a [`TcpStream`], found in the standard library, to
 /// be configured using all the additional methods found in the [`Socket`] API.
 ///
-/// `SockRef` can be created from any socket type that implements [`AsRawFd`]
-/// (Unix) or [`AsRawSocket`] (Windows) using the [`From`] implementation, but
-/// the caller must ensure the file descriptor/socket is a valid.
+/// `SockRef` can be created from any socket type that implements [`AsFd`]
+/// (Unix) or [`AsSocket`] (Windows) using the [`From`] implementation.
 ///
 /// [`TcpStream`]: std::net::TcpStream
 // Don't use intra-doc links because they won't build on every platform.
-/// [`AsRawFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsRawFd.html
-/// [`AsRawSocket`]: https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsRawSocket.html
+/// [`AsFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/trait.AsFd.html
+/// [`AsSocket`]: https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsSocket.html
 ///
 /// # Examples
 ///
@@ -59,29 +58,6 @@ use crate::Socket;
 /// # Ok(())
 /// # }
 /// ```
-///
-/// Below is an example of **incorrect usage** of `SockRef::from`, which is
-/// currently possible (but not intended and will be fixed in future versions).
-///
-/// ```compile_fail
-/// use socket2::SockRef;
-///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// /// THIS USAGE IS NOT VALID!
-/// let socket_ref = SockRef::from(&123);
-/// // The above line is overseen possibility when using `SockRef::from`, it
-/// // uses the `RawFd` (on Unix), which is a type alias for `c_int`/`i32`,
-/// // which implements `AsRawFd`. However it may be clear that this usage is
-/// // invalid as it doesn't guarantee that `123` is a valid file descriptor.
-///
-/// // Using `Socket::set_nodelay` now will call it on a file descriptor we
-/// // don't own! We don't even not if the file descriptor is valid or a socket.
-/// socket_ref.set_nodelay(true)?;
-/// drop(socket_ref);
-/// # Ok(())
-/// # }
-/// # DO_NOT_COMPILE
-/// ```
 pub struct SockRef<'s> {
     /// Because this is a reference we don't own the `Socket`, however `Socket`
     /// closes itself when dropped, so we use `ManuallyDrop` to prevent it from
@@ -100,16 +76,16 @@ impl<'s> Deref for SockRef<'s> {
     }
 }
 
-/// On Windows, a corresponding `From<&impl AsRawSocket>` implementation exists.
+/// On Windows, a corresponding `From<&impl AsSocket>` implementation exists.
 #[cfg(unix)]
 #[cfg_attr(docsrs, doc(cfg(unix)))]
 impl<'s, S> From<&'s S> for SockRef<'s>
 where
-    S: AsRawFd,
+    S: AsFd,
 {
     /// The caller must ensure `S` is actually a socket.
     fn from(socket: &'s S) -> Self {
-        let fd = socket.as_raw_fd();
+        let fd = socket.as_fd().as_raw_fd();
         assert!(fd >= 0);
         SockRef {
             socket: ManuallyDrop::new(unsafe { Socket::from_raw_fd(fd) }),
@@ -118,16 +94,16 @@ where
     }
 }
 
-/// On Unix, a corresponding `From<&impl AsRawFd>` implementation exists.
+/// On Unix, a corresponding `From<&impl AsFd>` implementation exists.
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(windows)))]
 impl<'s, S> From<&'s S> for SockRef<'s>
 where
-    S: AsRawSocket,
+    S: AsSocket,
 {
-    /// See the `From<&impl AsRawFd>` implementation.
+    /// See the `From<&impl AsFd>` implementation.
     fn from(socket: &'s S) -> Self {
-        let socket = socket.as_raw_socket();
+        let socket = socket.as_socket().as_raw_socket();
         assert!(socket != windows_sys::Win32::Networking::WinSock::INVALID_SOCKET as _);
         SockRef {
             socket: ManuallyDrop::new(unsafe { Socket::from_raw_socket(socket) }),


### PR DESCRIPTION
I've merged the commits from #324 into this one as is was missing the implementations for `SockRef`, the most important bit.

This implements:
 * The AsFd and AsSocket traits for Socket.
 * From<OwnedFd> and From<OwnedSocket> for Socket.
 * From<Socket> for OwnedFd and OwnedSocket.

Replacing AsRawFd with AsFd and AsRawSocket with AsSocket for SockRef.

Closed #218.