### PR TITLE
Move Redox to stable checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,32 +61,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: add the following targets, currently broken.
-        # "x86_64-unknown-redox"
-        target: ["aarch64-apple-ios", "aarch64-linux-android", "x86_64-apple-darwin", "x86_64-fuchsia", "x86_64-pc-windows-msvc", "x86_64-pc-solaris", "x86_64-unknown-illumos", "x86_64-unknown-linux-gnu", "x86_64-unknown-netbsd"]
+        target: ["aarch64-apple-ios", "aarch64-linux-android", "x86_64-apple-darwin", "x86_64-fuchsia", "x86_64-pc-windows-msvc", "x86_64-pc-solaris", "x86_64-unknown-illumos", "x86_64-unknown-linux-gnu", "x86_64-unknown-netbsd", "x86_64-unknown-redox"]
     steps:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - name: Install Target
-      run: rustup target add ${{ matrix.target }}
-    - name: Install cargo-hack
-      uses: taiki-e/install-action@cargo-hack
-    - name: Run check
-      run: cargo hack check --feature-powerset --all-targets --examples --bins --tests --target ${{ matrix.target }}
-
-  # Redox needs a nightly compiler for libc:
-  # https://github.com/rust-lang/libc/issues/2012
-  Check_Redox:
-    name: Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: ["x86_64-unknown-redox"]
-    steps:
-    - uses: actions/checkout@master
-    - name: Install Rust nightly
-      run: rustup update nightly && rustup default nightly
     - name: Install Target
       run: rustup target add ${{ matrix.target }}
     - name: Install cargo-hack


### PR DESCRIPTION
It should be able to be compiled with a stable compiler since
https://github.com/rust-lang/libc/pull/2728.

Fixes #181.