### PR TITLE
Rename SockAddr::init to try_init

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -101,7 +101,7 @@ impl SockAddr {
     ///
     /// // Initialise a `SocketAddr` byte calling `getsockname(2)`.
     /// let (_, address) = unsafe {
-    ///     SockAddr::init(|addr_storage, len| {
+    ///     SockAddr::try_init(|addr_storage, len| {
     ///         // The `getsockname(2)` system call will intiliase `storage` for
     ///         // us, setting `len` to the correct length.
     ///         if libc::getsockname(socket.as_raw_fd(), addr_storage.cast(), len) == -1 {
@@ -116,7 +116,7 @@ impl SockAddr {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn init<F, T>(init: F) -> io::Result<(T, SockAddr)>
+    pub unsafe fn try_init<F, T>(init: F) -> io::Result<(T, SockAddr)>
     where
         F: FnOnce(*mut sockaddr_storage, *mut socklen_t) -> io::Result<T>,
     {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -311,7 +311,7 @@ pub(crate) fn listen(socket: Socket, backlog: c_int) -> io::Result<()> {
 pub(crate) fn accept(socket: Socket) -> io::Result<(Socket, SockAddr)> {
     // Safety: `accept` initialises the `SockAddr` for us.
     unsafe {
-        SockAddr::init(|storage, len| {
+        SockAddr::try_init(|storage, len| {
             syscall!(
                 accept(socket, storage.cast(), len),
                 PartialEq::eq,
@@ -324,7 +324,7 @@ pub(crate) fn accept(socket: Socket) -> io::Result<(Socket, SockAddr)> {
 pub(crate) fn getsockname(socket: Socket) -> io::Result<SockAddr> {
     // Safety: `getsockname` initialises the `SockAddr` for us.
     unsafe {
-        SockAddr::init(|storage, len| {
+        SockAddr::try_init(|storage, len| {
             syscall!(
                 getsockname(socket, storage.cast(), len),
                 PartialEq::eq,
@@ -338,7 +338,7 @@ pub(crate) fn getsockname(socket: Socket) -> io::Result<SockAddr> {
 pub(crate) fn getpeername(socket: Socket) -> io::Result<SockAddr> {
     // Safety: `getpeername` initialises the `SockAddr` for us.
     unsafe {
-        SockAddr::init(|storage, len| {
+        SockAddr::try_init(|storage, len| {
             syscall!(
                 getpeername(socket, storage.cast(), len),
                 PartialEq::eq,
@@ -443,7 +443,7 @@ pub(crate) fn recv_from(
 ) -> io::Result<(usize, SockAddr)> {
     // Safety: `recvfrom` initialises the `SockAddr` for us.
     unsafe {
-        SockAddr::init(|storage, addrlen| {
+        SockAddr::try_init(|storage, addrlen| {
             let res = syscall!(
                 recvfrom(
                     socket,
@@ -472,7 +472,7 @@ pub(crate) fn recv_from_vectored(
 ) -> io::Result<(usize, RecvFlags, SockAddr)> {
     // Safety: `recvfrom` initialises the `SockAddr` for us.
     unsafe {
-        SockAddr::init(|storage, addrlen| {
+        SockAddr::try_init(|storage, addrlen| {
             let mut nread = 0;
             let mut flags = flags as u32;
             let res = syscall!(


### PR DESCRIPTION
To match the function signature, which returns a result. Also allows to
add an `init` function that never fails, if ever needed.

Updates #231.