### PR TITLE
TCP_FASTOPEN option for Socket

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -157,6 +157,17 @@ use libc::TCP_KEEPALIVE as KEEPALIVE_TIME;
 #[cfg(not(any(target_vendor = "apple", target_os = "haiku", target_os = "openbsd")))]
 use libc::TCP_KEEPIDLE as KEEPALIVE_TIME;
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos"
+))]
+pub(crate) use libc::TCP_FASTOPEN;
+
 /// Helper macro to execute a system call that returns an `io::Result`.
 macro_rules! syscall {
     ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -78,6 +78,8 @@ pub(crate) use windows_sys::Win32::Networking::WinSock::{
 };
 pub(crate) const IPPROTO_IP: c_int = windows_sys::Win32::Networking::WinSock::IPPROTO_IP as c_int;
 pub(crate) const SOL_SOCKET: c_int = windows_sys::Win32::Networking::WinSock::SOL_SOCKET as c_int;
+pub(crate) const TCP_FASTOPEN: c_int =
+    windows_sys::Win32::Networking::WinSock::TCP_FASTOPEN as c_int;
 
 /// Type used in set/getsockopt to retrieve the `TCP_NODELAY` option.
 ///


### PR DESCRIPTION
- Supported platforms: Linux-like, FreeBSD, macOS, Windows
- ref #49