### PR TITLE
fix build on DragonFly: IP_RECVTOS and join_leave_ssm_v4() disabled

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1418,6 +1418,7 @@ impl Socket {
     /// incoming packets. It contains a byte which specifies the
     /// Type of Service/Precedence field of the packet header.
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "fuchsia",
         target_os = "illumos",
         target_os = "netbsd",
@@ -1444,6 +1445,7 @@ impl Socket {
     ///
     /// [`set_recv_tos`]: Socket::set_recv_tos
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "fuchsia",
         target_os = "illumos",
         target_os = "netbsd",

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1215,6 +1215,7 @@ impl Socket {
     /// multicast group. If it's [`Ipv4Addr::UNSPECIFIED`] (`INADDR_ANY`) then
     /// an appropriate interface is chosen by the system.
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "redox",
@@ -1247,6 +1248,7 @@ impl Socket {
     ///
     /// [`join_ssm_v4`]: Socket::join_ssm_v4
     #[cfg(not(any(
+        target_os = "dragonfly",
         target_os = "haiku",
         target_os = "netbsd",
         target_os = "redox",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -75,6 +75,7 @@ pub(crate) use libc::{MSG_TRUNC, SO_OOBINLINE};
 #[cfg(all(feature = "all", not(target_os = "redox")))]
 pub(crate) use libc::IP_HDRINCL;
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "netbsd",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -103,6 +103,7 @@ pub(crate) use libc::{
     SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
 };
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "redox",

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1186,6 +1186,7 @@ test!(IPv4 ttl, set_ttl(40));
 test!(IPv4 tos, set_tos(96));
 
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "netbsd",
@@ -1244,6 +1245,7 @@ fn join_leave_multicast_v4_n() {
 
 #[test]
 #[cfg(not(any(
+    target_os = "dragonfly",
     target_os = "haiku",
     target_os = "netbsd",
     target_os = "redox",


### PR DESCRIPTION
Well, it makes build and tests clean. Not sure if I'm doing it right though.

Also IP_RECVTOS support issue do prevent socket2 v0.4.6 building.