### PR TITLE
V0.5 alpha openbsd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,10 +380,16 @@ impl<'a> DerefMut for MaybeUninitSlice<'a> {
 /// See [`Socket::set_tcp_keepalive`].
 #[derive(Debug, Clone)]
 pub struct TcpKeepalive {
+    #[cfg_attr(target_os = "openbsd", allow(dead_code))]
     time: Option<Duration>,
-    #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
+    #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
     interval: Option<Duration>,
-    #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "windows")))]
+    #[cfg(not(any(
+        target_os = "openbsd",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "windows"
+    )))]
     retries: Option<u32>,
 }
 
@@ -392,9 +398,14 @@ impl TcpKeepalive {
     pub const fn new() -> TcpKeepalive {
         TcpKeepalive {
             time: None,
-            #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
+            #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
             interval: None,
-            #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "windows")))]
+            #[cfg(not(any(
+                target_os = "openbsd",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "windows"
+            )))]
             retries: None,
         }
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1218,6 +1218,7 @@ impl Socket {
         target_os = "dragonfly",
         target_os = "haiku",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "fuchsia",
     )))]
@@ -1251,6 +1252,7 @@ impl Socket {
         target_os = "dragonfly",
         target_os = "haiku",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "redox",
         target_os = "fuchsia",
     )))]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -106,6 +106,7 @@ pub(crate) use libc::{
     target_os = "dragonfly",
     target_os = "haiku",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "fuchsia",
 )))]

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1190,6 +1190,7 @@ test!(IPv4 tos, set_tos(96));
     target_os = "fuchsia",
     target_os = "illumos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
     target_os = "windows",

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1201,7 +1201,12 @@ test!(IPv4 recv_tos, set_recv_tos(true));
 test!(IPv4 broadcast, set_broadcast(true));
 
 test!(IPv6 unicast_hops_v6, set_unicast_hops_v6(20));
-#[cfg(not(any(windows, target_os = "dragonfly", target_os = "freebsd")))]
+#[cfg(not(any(
+    windows,
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd"
+)))]
 test!(IPv6 only_v6, set_only_v6(true));
 // IPv6 socket are already IPv6 only on FreeBSD and Windows.
 #[cfg(any(windows, target_os = "freebsd"))]

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1220,6 +1220,7 @@ test!(
     target_os = "haiku",
     target_os = "illumos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
 )))]
@@ -1248,6 +1249,7 @@ fn join_leave_multicast_v4_n() {
     target_os = "dragonfly",
     target_os = "haiku",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "fuchsia",
 )))]


### PR DESCRIPTION
For OpenBSD, current master is broken.  I made some fixes to the conditional compilation configuration in the following areas:

per-socket keepalive parameters
Ipv4 source specific multicast
RECVTOS
ipv6 only
Tested on a system derived from OpenBSD 7.1, the latest published OpenBSD version.