### PR TITLE
support IPPROTO_MPTCP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,10 @@ impl Protocol {
 
     /// Protocol corresponding to `UDP`.
     pub const UDP: Protocol = Protocol(sys::IPPROTO_UDP);
+
+    #[cfg(target_os = "linux")]
+    /// Protocol corresponding to `MPTCP`.
+    pub const MPTCP: Protocol = Protocol(sys::IPPROTO_MPTCP);
 }
 
 impl From<c_int> for Protocol {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -63,6 +63,8 @@ pub(crate) use libc::SOCK_RAW;
 pub(crate) use libc::SOCK_SEQPACKET;
 pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
 // Used in `Protocol`.
+#[cfg(target_os = "linux")]
+pub(crate) use libc::IPPROTO_MPTCP;
 pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
 // Used in `SockAddr`.
 pub(crate) use libc::{
@@ -386,6 +388,8 @@ impl_debug!(
     libc::IPPROTO_ICMPV6,
     libc::IPPROTO_TCP,
     libc::IPPROTO_UDP,
+    #[cfg(target_os = "linux")]
+    libc::IPPROTO_MPTCP,
 );
 
 /// Unix-only API.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -106,6 +106,8 @@ fn protocol_fmt_debug() {
         (Protocol::ICMPV6, "IPPROTO_ICMPV6"),
         (Protocol::TCP, "IPPROTO_TCP"),
         (Protocol::UDP, "IPPROTO_UDP"),
+        #[cfg(target_os = "linux")]
+        (Protocol::MPTCP, "IPPROTO_MPTCP"),
         (500.into(), "500"),
     ];
 


### PR DESCRIPTION
Simply add the support for MPTCP protocol by adding and exposing the MPTCP const Protocol.

MPTCP allow end user to open multiple path (TCP) to the destination server using multiple interface. For example, one can use the LTE connection of his phone as well as a Wifi connection. Or Ethernet and Wifi.

Setting this Protocol will fail if the host does not support MPTCP, thus the fallback is to open as TCP like one would normally do.

For reference: `sysctl net.mptcp.enabled=1`

I'm not sure about adding test as this imply that the host must support MPTCP, open for feedback on this :)

Signed-off-by: Martin Andre <martin.andre@tessares.net>