### PR TITLE
support IPPROTO_SCTP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,13 +307,7 @@ impl Protocol {
     /// Protocol corresponding to `MPTCP`.
     pub const MPTCP: Protocol = Protocol(sys::IPPROTO_MPTCP);
 
-    #[cfg(all(
-        feature = "all",
-        any(
-            target_os = "freebsd",
-            target_os = "linux",
-        )
-    ))]
+    #[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
     /// Protocol corresponding to `SCTP`.
     pub const SCTP: Protocol = Protocol(sys::IPPROTO_SCTP);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,16 @@ impl Protocol {
     #[cfg(target_os = "linux")]
     /// Protocol corresponding to `MPTCP`.
     pub const MPTCP: Protocol = Protocol(sys::IPPROTO_MPTCP);
+
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "freebsd",
+            target_os = "linux",
+        )
+    ))]
+    /// Protocol corresponding to `SCTP`.
+    pub const SCTP: Protocol = Protocol(sys::IPPROTO_SCTP);
 }
 
 impl From<c_int> for Protocol {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -65,6 +65,14 @@ pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
 // Used in `Protocol`.
 #[cfg(target_os = "linux")]
 pub(crate) use libc::IPPROTO_MPTCP;
+#[cfg(all(
+    feature = "all",
+    any(
+        target_os = "freebsd",
+        target_os = "linux",
+    )
+))]
+pub(crate) use libc::IPPROTO_SCTP;
 pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
 // Used in `SockAddr`.
 pub(crate) use libc::{
@@ -390,6 +398,14 @@ impl_debug!(
     libc::IPPROTO_UDP,
     #[cfg(target_os = "linux")]
     libc::IPPROTO_MPTCP,
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "freebsd",
+            target_os = "linux",
+        )
+    ))]
+    libc::IPPROTO_SCTP,
 );
 
 /// Unix-only API.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -65,13 +65,7 @@ pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
 // Used in `Protocol`.
 #[cfg(target_os = "linux")]
 pub(crate) use libc::IPPROTO_MPTCP;
-#[cfg(all(
-    feature = "all",
-    any(
-        target_os = "freebsd",
-        target_os = "linux",
-    )
-))]
+#[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
 pub(crate) use libc::IPPROTO_SCTP;
 pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
 // Used in `SockAddr`.
@@ -398,13 +392,7 @@ impl_debug!(
     libc::IPPROTO_UDP,
     #[cfg(target_os = "linux")]
     libc::IPPROTO_MPTCP,
-    #[cfg(all(
-        feature = "all",
-        any(
-            target_os = "freebsd",
-            target_os = "linux",
-        )
-    ))]
+    #[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
     libc::IPPROTO_SCTP,
 );
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -108,6 +108,14 @@ fn protocol_fmt_debug() {
         (Protocol::UDP, "IPPROTO_UDP"),
         #[cfg(target_os = "linux")]
         (Protocol::MPTCP, "IPPROTO_MPTCP"),
+        #[cfg(all(
+            feature = "all",
+            any(
+                target_os = "freebsd",
+                target_os = "linux",
+            )
+        ))]
+        (Protocol::SCTP, "IPPROTO_SCTP"),
         (500.into(), "500"),
     ];
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -108,13 +108,7 @@ fn protocol_fmt_debug() {
         (Protocol::UDP, "IPPROTO_UDP"),
         #[cfg(target_os = "linux")]
         (Protocol::MPTCP, "IPPROTO_MPTCP"),
-        #[cfg(all(
-            feature = "all",
-            any(
-                target_os = "freebsd",
-                target_os = "linux",
-            )
-        ))]
+        #[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
         (Protocol::SCTP, "IPPROTO_SCTP"),
         (500.into(), "500"),
     ];


### PR DESCRIPTION
Adds the bare minimum needed to support SCTP sockets (IPPROTO_SCTP) as a protocol option for Linux and FreeBSD. Note that this does not include socket options specific to SCTP, as the constants and structs required have not been added to the libc crate.

Resolves #202 