### PR TITLE
Add support for SO_ORIGINAL_DST and IP6T_SO_ORIGINAL_DST.

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1793,10 +1793,16 @@ impl crate::Socket {
     ///
     /// This value contains the original destination IPv4 address of the connection
     /// redirected using `iptables` `REDIRECT` or `TPROXY`.
-    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg(all(
+        feature = "all",
+        any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    ))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+        doc(cfg(all(
+            feature = "all",
+            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+        )))
     )]
     pub fn original_dst(&self) -> io::Result<SockAddr> {
         // Safety: `getsockopt` initialises the `SockAddr` for us.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1798,7 +1798,7 @@ impl crate::Socket {
         docsrs,
         doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
     )]
-    pub fn original_dst(&self) -> io::Result<Option<SockAddr>> {
+    pub fn original_dst(&self) -> io::Result<SockAddr> {
         // Safety: `getsockopt` initialises the `SockAddr` for us.
         unsafe {
             SockAddr::try_init(|storage, len| {
@@ -1811,13 +1811,7 @@ impl crate::Socket {
                 ))
             })
         }
-        .map_or_else(
-            |e| match e.raw_os_error() {
-                Some(libc::ENOENT) => Ok(None),
-                _ => Err(e),
-            },
-            |(_, addr)| Ok(Some(addr)),
-        )
+        .map(|(_, addr)| addr)
     }
 
     /// Get the value for the `IP6T_SO_ORIGINAL_DST` option on this socket.
@@ -1829,7 +1823,7 @@ impl crate::Socket {
         docsrs,
         doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
     )]
-    pub fn original_dst_ipv6(&self) -> io::Result<Option<SockAddr>> {
+    pub fn original_dst_ipv6(&self) -> io::Result<SockAddr> {
         // Safety: `getsockopt` initialises the `SockAddr` for us.
         unsafe {
             SockAddr::try_init(|storage, len| {
@@ -1842,13 +1836,7 @@ impl crate::Socket {
                 ))
             })
         }
-        .map_or_else(
-            |e| match e.raw_os_error() {
-                Some(libc::ENOENT) => Ok(None),
-                _ => Err(e),
-            },
-            |(_, addr)| Ok(Some(addr)),
-        )
+        .map(|(_, addr)| addr)
     }
 
     /// Copies data between a `file` and this socket using the `sendfile(2)`

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1297,3 +1297,39 @@ fn header_included() {
     let got = socket.header_included().expect("failed to get value");
     assert_eq!(got, true, "set and get values differ");
 }
+
+#[test]
+#[cfg(all(
+    feature = "all",
+    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+))]
+fn original_dst() {
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    match socket.original_dst() {
+        Ok(_) => panic!("original_dst on non-redirected socket should fail"),
+        Err(err) => assert_eq!(err.raw_os_error(), Some(libc::ENOENT)),
+    }
+
+    let socket = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+    match socket.original_dst() {
+        Ok(_) => panic!("original_dst on non-redirected socket should fail"),
+        Err(err) => assert_eq!(err.raw_os_error(), Some(libc::ENOENT)),
+    }
+}
+
+#[test]
+#[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+fn original_dst_ipv6() {
+    let socket = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+    match socket.original_dst_ipv6() {
+        Ok(_) => panic!("original_dst_ipv6 on non-redirected socket should fail"),
+        Err(err) => assert_eq!(err.raw_os_error(), Some(libc::ENOENT)),
+    }
+
+    // Not supported on IPv4 socket.
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    match socket.original_dst_ipv6() {
+        Ok(_) => panic!("original_dst_ipv6 on non-redirected socket should fail"),
+        Err(err) => assert_eq!(err.raw_os_error(), Some(libc::EOPNOTSUPP)),
+    }
+}


### PR DESCRIPTION
Those values contain the original destination IPv4/IPv6 address
of the connection redirected using iptables REDIRECT or TPROXY.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>