### PR TITLE
hotfix: replace `unused_unsafe` with `unsafe_op_in_unsafe_in`

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -474,7 +474,7 @@ impl<'a> MaybeUninitSlice<'a> {
     }
 }
 
-#[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
+#[allow(unsafe_op_in_unsafe_fn)]
 pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     // SAFETY: a `sockaddr_storage` of all zeros is valid.
     let mut storage = unsafe { mem::zeroed::<sockaddr_storage>() };
@@ -529,7 +529,7 @@ impl SockAddr {
     ///
     /// This function can never fail. In a future version of this library it will be made
     /// infallible.
-    #[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
+    #[allow(unsafe_op_in_unsafe_fn)]
     #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
     #[cfg_attr(
         docsrs,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -776,7 +776,7 @@ pub(crate) fn to_mreqn(
     }
 }
 
-#[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
+#[allow(unsafe_op_in_unsafe_fn)]
 pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     // SAFETY: a `sockaddr_storage` of all zeros is valid.
     let mut storage = unsafe { mem::zeroed::<sockaddr_storage>() };


### PR DESCRIPTION
Replace `unused_unsafe` with [unsafe_op_in_unsafe_in](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.UNSAFE_OP_IN_UNSAFE_FN.html) since it's already [stablized](https://github.com/rust-lang/rust/pull/79208).