### PR TITLE
Allow compilation on haiku beta 4

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1442,6 +1442,7 @@ impl Socket {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
+        target_os = "haiku",
     )))]
     pub fn set_recv_tos(&self, recv_tos: bool) -> io::Result<()> {
         unsafe {
@@ -1467,6 +1468,7 @@ impl Socket {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
+        target_os = "haiku",
     )))]
     pub fn recv_tos(&self) -> io::Result<bool> {
         unsafe {
@@ -1679,6 +1681,7 @@ impl Socket {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
+        target_os = "haiku",
     )))]
     pub fn recv_tclass_v6(&self) -> io::Result<bool> {
         unsafe {
@@ -1700,6 +1703,7 @@ impl Socket {
         target_os = "openbsd",
         target_os = "redox",
         target_os = "solaris",
+        target_os = "haiku",
     )))]
     pub fn set_recv_tclass_v6(&self, recv_tclass: bool) -> io::Result<()> {
         unsafe {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -84,6 +84,7 @@ pub(crate) use libc::{MSG_TRUNC, SO_OOBINLINE};
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "haiku",
 )))]
 pub(crate) use libc::IPV6_RECVTCLASS;
 #[cfg(all(feature = "all", not(target_os = "redox")))]
@@ -96,6 +97,7 @@ pub(crate) use libc::IP_HDRINCL;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "haiku",
 )))]
 pub(crate) use libc::IP_RECVTOS;
 #[cfg(not(any(


### PR DESCRIPTION
I am running haiku beta 4 with rust installed from their package manager.
When trying to compile the matrix weechat rust plugin, the build failed while compiling the socket2 dependency.
After some investigation, it seems that haiku is lacking `libc::IPV6_RECVTCLASS` and ` libc::IP_RECVTOS`.
In this PR, I disable these 2 features for Haiku in the socket2 code, after that I was able to compile the library successfully.
However I did not test this code yet.