### PR TITLE
Add support for TCP_CONGESTION socketopt

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -204,6 +204,7 @@ const MAX_BUF_LEN: usize = ssize_t::MAX as usize;
 #[cfg(target_vendor = "apple")]
 const MAX_BUF_LEN: usize = c_int::MAX as usize - 1;
 
+// TCP_CA_NAME_MAX isn't defined in user space include files(not in libc)
 #[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
 const TCP_CA_NAME_MAX: usize = 16;
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -2180,8 +2180,9 @@ impl crate::Socket {
         ))
         .map(|_| {
             let buf = unsafe { payload.assume_init() };
-            let name = buf.splitn(2, |num| *num == 0).next().unwrap().to_vec();
-            name
+            let buf = &buf[..len as usize];
+            // TODO: use `MaybeUninit::slice_assume_init_ref` once stable.
+            unsafe { &*(buf as *const [_] as *const [u8]) }.into()
         })
     }
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1371,11 +1371,14 @@ fn tcp_congestion() {
         b"newreno",
     ];
     // Set a new tcp ca
+    #[cfg(target_os = "linux")]
     let new_tcp_ca = if cur_tcp_ca == OPTIONS[0] {
         OPTIONS[1]
     } else {
         OPTIONS[0]
     };
+    #[cfg(target_os = "freebsd")]
+    let new_tcp_ca = OPTIONS[1];
     socket.set_tcp_congestion(new_tcp_ca).unwrap();
     // Check if new tcp ca is successfully set
     let cur_tcp_ca = socket.tcp_congestion().unwrap();

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1347,7 +1347,7 @@ fn original_dst_ipv6() {
 fn tcp_congestion() {
     let socket: Socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
     // Get and set current tcp_ca
-    let origin_tcp_ca: String = socket
+    let origin_tcp_ca = socket
         .tcp_congestion()
         .expect("failed to get tcp congestion algorithm");
     socket
@@ -1355,11 +1355,11 @@ fn tcp_congestion() {
         .expect("failed to set tcp congestion algorithm");
     // Return a Err when set a non-exist tcp_ca
     socket
-        .set_tcp_congestion("tcp_congestion_does_not_exist")
+        .set_tcp_congestion(b"tcp_congestion_does_not_exist")
         .unwrap_err();
     let cur_tcp_ca = socket.tcp_congestion().unwrap();
     assert_eq!(
         cur_tcp_ca, origin_tcp_ca,
-        "expected {origin_tcp_ca} but get {cur_tcp_ca}"
+        "expected {origin_tcp_ca:?} but get {cur_tcp_ca:?}"
     );
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1362,4 +1362,26 @@ fn tcp_congestion() {
         cur_tcp_ca, origin_tcp_ca,
         "expected {origin_tcp_ca:?} but get {cur_tcp_ca:?}"
     );
+    let cur_tcp_ca = cur_tcp_ca.splitn(2, |num| *num == 0).next().unwrap();
+    const OPTIONS: [&[u8]; 2] = [
+        b"cubic",
+        #[cfg(target_os = "linux")] // or Android.
+        b"reno",
+        #[cfg(target_os = "freebsd")]
+        b"newreno",
+    ];
+    // Set a new tcp ca
+    let new_tcp_ca = if cur_tcp_ca == OPTIONS[0] {
+        OPTIONS[1]
+    } else {
+        OPTIONS[0]
+    };
+    socket.set_tcp_congestion(new_tcp_ca).unwrap();
+    // Check if new tcp ca is successfully set
+    let cur_tcp_ca = socket.tcp_congestion().unwrap();
+    assert_eq!(
+        cur_tcp_ca.splitn(2, |num| *num == 0).next().unwrap(),
+        new_tcp_ca,
+        "expected {new_tcp_ca:?}, but get {cur_tcp_ca:?}"
+    );
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1385,6 +1385,5 @@ fn tcp_congestion() {
     assert_eq!(
         cur_tcp_ca.splitn(2, |num| *num == 0).next().unwrap(),
         new_tcp_ca,
-        "expected {new_tcp_ca:?}, but get {cur_tcp_ca:?}"
     );
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1341,3 +1341,25 @@ fn original_dst_ipv6() {
         Err(err) => assert_eq!(err.raw_os_error(), Some(libc::EOPNOTSUPP)),
     }
 }
+
+#[test]
+#[cfg(all(feature = "all", any(target_os = "freebsd", target_os = "linux")))]
+fn tcp_congestion() {
+    let socket: Socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    // Get and set current tcp_ca
+    let origin_tcp_ca: String = socket
+        .tcp_congestion()
+        .expect("failed to get tcp congestion algorithm");
+    socket
+        .set_tcp_congestion(&origin_tcp_ca)
+        .expect("failed to set tcp congestion algorithm");
+    // Return a Err when set a non-exist tcp_ca
+    socket
+        .set_tcp_congestion("tcp_congestion_does_not_exist")
+        .unwrap_err();
+    let cur_tcp_ca = socket.tcp_congestion().unwrap();
+    assert_eq!(
+        cur_tcp_ca, origin_tcp_ca,
+        "expected {origin_tcp_ca} but get {cur_tcp_ca}"
+    );
+}


### PR DESCRIPTION
- `tcp_congestion` uses raw syscall since diff os have diff policy on modifying len
- `set_tcp_congestion` uses raw syscall since exact str len must be passed in

Closes: #370 

Co-authored-by: Campbell He <kp.campbell.he@duskmoon314.com>