### PR TITLE
Remove usage of target_vendor = "apple"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,10 +475,11 @@ impl TcpKeepalive {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
-            windows,
+            target_os = "windows",
         )
     ))]
     #[cfg_attr(
@@ -491,10 +492,11 @@ impl TcpKeepalive {
                 target_os = "freebsd",
                 target_os = "fuchsia",
                 target_os = "illumos",
+                target_os = "ios",
                 target_os = "linux",
+                target_os = "macos",
                 target_os = "netbsd",
-                target_vendor = "apple",
-                windows,
+                target_os = "windows",
             )
         )))
     )]
@@ -517,9 +519,10 @@ impl TcpKeepalive {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     #[cfg_attr(
@@ -532,9 +535,10 @@ impl TcpKeepalive {
                 target_os = "freebsd",
                 target_os = "fuchsia",
                 target_os = "illumos",
+                target_os = "ios",
                 target_os = "linux",
+                target_os = "macos",
                 target_os = "netbsd",
-                target_vendor = "apple",
             )
         )))
     )]

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -770,7 +770,7 @@ fn set_common_flags(socket: Socket) -> io::Result<Socket> {
     socket._set_cloexec(true)?;
 
     // On Apple platforms set `NOSIGPIPE`.
-    #[cfg(target_vendor = "apple")]
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
     socket._set_nosigpipe(true)?;
 
     Ok(socket)
@@ -1794,9 +1794,10 @@ impl Socket {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     #[cfg_attr(
@@ -1809,9 +1810,10 @@ impl Socket {
                 target_os = "freebsd",
                 target_os = "fuchsia",
                 target_os = "illumos",
+                target_os = "ios",
                 target_os = "linux",
+                target_os = "macos",
                 target_os = "netbsd",
-                target_vendor = "apple",
             )
         )))
     )]
@@ -1835,9 +1837,10 @@ impl Socket {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     #[cfg_attr(
@@ -1850,9 +1853,10 @@ impl Socket {
                 target_os = "freebsd",
                 target_os = "fuchsia",
                 target_os = "illumos",
+                target_os = "ios",
                 target_os = "linux",
+                target_os = "macos",
                 target_os = "netbsd",
-                target_vendor = "apple",
             )
         )))
     )]

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -4,8 +4,9 @@
     any(
         target_os = "android",
         target_os = "freebsd",
+        target_os = "ios",
         target_os = "linux",
-        target_vendor = "apple",
+        target_os = "macos",
     )
 ))]
 use std::fs::File;
@@ -23,8 +24,9 @@ use std::net::{Ipv6Addr, SocketAddrV6};
     any(
         target_os = "android",
         target_os = "freebsd",
+        target_os = "ios",
         target_os = "linux",
-        target_vendor = "apple",
+        target_os = "macos",
     )
 ))]
 use std::num::NonZeroUsize;
@@ -175,7 +177,7 @@ fn set_nonblocking() {
 fn assert_common_flags(socket: &Socket, expected: bool) {
     #[cfg(unix)]
     assert_close_on_exec(socket, expected);
-    #[cfg(target_vendor = "apple")]
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
     assert_flag_no_sigpipe(socket, expected);
     #[cfg(windows)]
     assert_flag_no_inherit(socket, expected);
@@ -292,7 +294,7 @@ where
     assert_eq!(flags & libc::FD_CLOEXEC != 0, want, "CLOEXEC option");
 }
 
-#[cfg(all(windows, feature = "all"))]
+#[cfg(all(feature = "all", windows))]
 #[test]
 fn set_no_inherit() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
@@ -332,7 +334,7 @@ where
     );
 }
 
-#[cfg(all(feature = "all", target_vendor = "apple"))]
+#[cfg(all(feature = "all", any(target_os = "ios", target_os = "macos")))]
 #[test]
 fn set_nosigpipe() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
@@ -346,7 +348,7 @@ fn set_nosigpipe() {
 }
 
 /// Assert that `SO_NOSIGPIPE` is set on `socket`.
-#[cfg(target_vendor = "apple")]
+#[cfg(any(target_os = "ios", target_os = "macos"))]
 #[track_caller]
 pub fn assert_flag_no_sigpipe<S>(socket: &S, want: bool)
 where
@@ -740,10 +742,11 @@ fn tcp_keepalive() {
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
-            windows,
+            target_os = "windows",
         )
     ))]
     let params = params.with_interval(Duration::from_secs(30));
@@ -754,9 +757,10 @@ fn tcp_keepalive() {
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "fuchsia",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     let params = params.with_retries(10);
@@ -778,9 +782,10 @@ fn tcp_keepalive() {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     assert_eq!(
@@ -796,9 +801,10 @@ fn tcp_keepalive() {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "illumos",
+            target_os = "ios",
             target_os = "linux",
+            target_os = "macos",
             target_os = "netbsd",
-            target_vendor = "apple",
         )
     ))]
     assert_eq!(socket.keepalive_retries().unwrap(), 10);
@@ -838,7 +844,7 @@ fn device() {
     panic!("failed to bind to any device.");
 }
 
-#[cfg(all(feature = "all", target_vendor = "apple"))]
+#[cfg(all(feature = "all", any(target_os = "ios", target_os = "macos")))]
 #[test]
 fn device() {
     // Some common network interface on macOS.
@@ -874,13 +880,15 @@ fn device() {
 
     panic!("failed to bind to any device.");
 }
+
 #[cfg(all(
     feature = "all",
     any(
         target_os = "android",
         target_os = "freebsd",
+        target_os = "ios",
         target_os = "linux",
-        target_vendor = "apple",
+        target_os = "macos",
     )
 ))]
 #[test]
@@ -1026,7 +1034,11 @@ fn r#type() {
     assert_eq!(socket.r#type().unwrap(), Type::DGRAM);
 
     // macos doesn't support seqpacket
-    #[cfg(all(unix, not(target_vendor = "apple"), feature = "all"))]
+    #[cfg(all(
+        unix,
+        not(any(target_os = "ios", target_os = "macos")),
+        feature = "all",
+    ))]
     {
         let socket = Socket::new(Domain::UNIX, Type::SEQPACKET, None).unwrap();
         assert_eq!(socket.r#type().unwrap(), Type::SEQPACKET);


### PR DESCRIPTION
Being deprecated, see:
 * <https://github.com/rust-lang/lang-team/issues/102>
 * <https://github.com/rust-lang/rust/issues/100343>