### PR TITLE
Set rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ possible intended.
 keywords      = ["io", "socket", "network"]
 categories    = ["api-bindings", "network-programming"]
 edition       = "2021"
+rust-version  = "1.63"
 include       = [
   "Cargo.toml",
   "LICENSE-APACHE",


### PR DESCRIPTION
Now that the MSRV is higher than 1.56 it should be safe to set rust-version in Cargo.toml.