### PR TITLE
Match the standard library's interface for unix sockets on unix.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ platforms the `all` feature is used, to indicate to the user that they're using
 API that might is not available on all platforms.
 
 The main `Socket` type is defined in `src/socket.rs` with additional methods
-defined on in the the `src/sys/*.rs` files, as per above. The methods on
+defined in the `src/sys/*.rs` files, as per above. The methods on
 `Socket` are split into multiple `impl` blocks. The first `impl` block contains
 a collection of system calls for creating and using the socket, e.g.
 `socket(2)`, `bind(2)`, `listen(2)`, etc. The other implementation blocks are
@@ -51,7 +51,7 @@ such as `Socket::freebind` which is (at the time of writing) only available on
 Android, Linux and Fuchsia, which is defined in the `src/sys/*.rs` files.
 
 Other types are mostly defined in `src/lib.rs`, except for `SockAddr` and
-`SockRef` which have there own file. These types follow the same structure as
+`SockRef` which have their own file. These types follow the same structure as
 `Socket`, where OS specific methods are defined in `src/sys/*.rs`, e.g.
 `Type::cloexec`.
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -19,7 +19,7 @@ use crate::Domain;
 /// [`SocketAddr`], [`SocketAddrV4`], and [`SocketAddrV6`] types.
 #[derive(Clone)]
 pub struct SockAddr {
-    pub(crate) storage: sockaddr_storage,
+    storage: sockaddr_storage,
     len: socklen_t,
 }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -346,8 +346,6 @@ unsafe fn any_as_u8_slice<T: Sized>(p: &T, size: usize) -> &[u8] {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
-    use crate::sys::offset_of_path;
     use super::*;
 
     #[test]
@@ -404,26 +402,6 @@ mod tests {
             assert!(addr.as_pathname().is_none());
             assert!(addr.as_abstract_namespace().is_none());
         }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unix_pathname() {
-        let path_str = "/whatever/path";
-        let path = Path::new(path_str);
-        let addr = SockAddr::unix(path).unwrap();
-        assert!(addr.is_unix());
-        assert!(!addr.is_unnamed());
-        assert!(!addr.is_ipv4());
-        assert!(!addr.is_ipv6());
-        assert_eq!(addr.family(), AF_UNIX as sa_family_t);
-        assert_eq!(addr.domain(), Domain::UNIX);
-        let storage = addr.as_sockaddr_un().unwrap();
-        // The + 1 is the terminating null.
-        assert_eq!(addr.len() as usize, offset_of_path(storage) + path_str.len() + 1);
-        assert_eq!(addr.as_pathname(), Some(path));
-        assert!(addr.as_socket_ipv4().is_none());
-        assert!(addr.as_socket_ipv6().is_none());
     }
 
     #[test]

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -184,8 +184,8 @@ impl SockAddr {
         self.storage.ss_family == AF_INET6 as sa_family_t
     }
 
-    /// Returns true if this address is for local interprocess communication, i.e. it is from the
-    /// `AF_UNIX` (AKA `AF_LOCAL`) family, false otherwise.
+    /// Returns true if this address is of a unix socket (for local interprocess communication),
+    /// i.e. it is from the `AF_UNIX` family, false otherwise.
     pub fn is_unix(&self) -> bool {
         self.storage.ss_family == AF_UNIX as sa_family_t
     }

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -7,7 +7,10 @@ use std::{fmt, io, ptr};
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::SOCKADDR_IN6_0;
 
-use crate::sys::{c_int, sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t, AF_INET, AF_INET6, AF_UNIX};
+use crate::sys::{
+    c_int, sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t, AF_INET,
+    AF_INET6, AF_UNIX,
+};
 use crate::Domain;
 
 /// The address of a socket.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -666,8 +666,8 @@ impl SockAddr {
         }
     }
 
-    /// Returns true if this address is an unnamed address from the `AF_UNIX` (AKA `AF_LOCAL`)
-    /// family (for local interprocess communication), false otherwise.
+    /// Returns true if this address is an unnamed address from the `AF_UNIX` family (for local
+    /// interprocess communication), false otherwise.
     pub fn is_unnamed(&self) -> bool {
         self.as_sockaddr_un()
             .map(|storage| {
@@ -684,8 +684,8 @@ impl SockAddr {
     /// otherwise returns `None`.
     pub(crate) fn as_sockaddr_un(&self) -> Option<&libc::sockaddr_un> {
         self.is_unix().then(|| {
-            // SAFETY: if local, i.e. the `ss_family` field is `AF_UNIX` then storage must be a
-            // `sockaddr_un`.
+            // SAFETY: if unix socket, i.e. the `ss_family` field is `AF_UNIX` then storage must be
+            // a `sockaddr_un`.
             unsafe { &*self.as_ptr().cast::<libc::sockaddr_un>() }
         })
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -569,6 +569,14 @@ impl<'a> MaybeUninitSlice<'a> {
     }
 }
 
+/// Returns the offset of the `sun_path` member of the passed unix socket address.
+pub(crate) fn offset_of_path(storage: &libc::sockaddr_un) -> usize {
+    let base = storage as *const _ as usize;
+    let path = ptr::addr_of!(storage.sun_path) as usize;
+    path - base
+}
+
+
 #[allow(unsafe_op_in_unsafe_fn)]
 pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     // SAFETY: a `sockaddr_storage` of all zeros is valid.
@@ -603,9 +611,7 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
             );
         }
 
-        let base = storage as *const _ as usize;
-        let path = ptr::addr_of!(storage.sun_path) as usize;
-        let sun_path_offset = path - base;
+        let sun_path_offset = offset_of_path(storage);
         sun_path_offset
             + bytes.len()
             + match bytes.first() {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -59,6 +59,7 @@ use std::path::Path;
 use std::ptr;
 use std::time::{Duration, Instant};
 use std::{io, slice};
+use std::ffi::OsStr;
 
 #[cfg(not(any(
     target_os = "ios",
@@ -95,7 +96,7 @@ pub(crate) use libc::IPPROTO_SCTP;
 pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
 // Used in `SockAddr`.
 pub(crate) use libc::{
-    sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_un, sockaddr_storage, socklen_t,
+    sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t,
 };
 // Used in `RecvFlags`.
 #[cfg(not(target_os = "redox"))]
@@ -570,7 +571,7 @@ impl<'a> MaybeUninitSlice<'a> {
 }
 
 /// Returns the offset of the `sun_path` member of the passed unix socket address.
-pub(crate) fn offset_of_path(storage: &sockaddr_un) -> usize {
+pub(crate) fn offset_of_path(storage: &libc::sockaddr_un) -> usize {
     let base = storage as *const _ as usize;
     let path = ptr::addr_of!(storage.sun_path) as usize;
     path - base
@@ -582,7 +583,7 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     // SAFETY: a `sockaddr_storage` of all zeros is valid.
     let mut storage = unsafe { mem::zeroed::<sockaddr_storage>() };
     let len = {
-        let storage = unsafe { &mut *ptr::addr_of_mut!(storage).cast::<sockaddr_un>() };
+        let storage = unsafe { &mut *ptr::addr_of_mut!(storage).cast::<libc::sockaddr_un>() };
 
         let bytes = path.as_os_str().as_bytes();
         let too_long = match bytes.first() {
@@ -664,6 +665,78 @@ impl SockAddr {
         } else {
             None
         }
+    }
+
+    /// Returns true if this address is an unnamed address from the `AF_UNIX` (AKA `AF_LOCAL`)
+    /// family (for local interprocess communication), false otherwise.
+    pub fn is_unnamed(&self) -> bool {
+        self.as_sockaddr_un()
+            .map(|storage| {
+                self.len() == offset_of_path(storage) as u32
+                    // On some non-linux platforms a zeroed path is returned for unnamed.
+                    // Abstract addresses only exist on Linux.
+                    || (cfg!(not(any(target_os = "linux", target_os = "android")))
+                    && storage.sun_path[0] == 0)
+            }).unwrap_or_default()
+    }
+
+    /// Returns the underlying `sockaddr_un` object if this addres is from the `AF_UNIX` family,
+    /// otherwise returns `None`.
+    pub(crate) fn as_sockaddr_un(&self) -> Option<&libc::sockaddr_un> {
+        self.is_unix()
+            .then(|| {
+                // SAFETY: if local, i.e. the `ss_family` field is `AF_UNIX` then storage must be a
+                // `sockaddr_un`.
+                unsafe { &*ptr::addr_of!(self.storage).cast::<libc::sockaddr_un>() }
+            })
+    }
+
+    /// Get the length of the path bytes of the address, not including any terminating null.
+    fn path_len(&self, storage: &libc::sockaddr_un, null_terminated: bool) -> usize {
+        self.len() as usize - offset_of_path(storage) - if null_terminated { 1 } else { 0 }
+    }
+
+    /// Get a u8 slice for the bytes of the pathname or abstract name.
+    fn path_bytes(&self, storage: &libc::sockaddr_un, null_terminated: bool) -> &[u8]{
+        let path_len = self.path_len(storage, null_terminated);
+        // SAFETY: the pointed objects of type `i8` have the same memory layout as `u8`. The path is
+        // the last field in the storage and so it length is equal to
+        //          TOTAL_LENGTH - OFFSET_OF_PATH -1        if the path is null-terminated.
+        //          TOTAL_LENGTH - OFFSET_OF_PATH           if the path is not null-terminated.
+        // There is no safe way to convert a `&[i8]` ot `&[u8]`
+        unsafe{ slice::from_raw_parts(storage.sun_path.as_ptr() as *const u8, path_len) }
+    }
+
+    /// Returns this address as a `Path` if it is an `AF_UNIX` pathname address, otherwise returns
+    /// `None`.
+    pub fn as_pathname(&self) -> Option<&Path> {
+        self.as_sockaddr_un()
+            .and_then(|storage| {
+                (self.len() > offset_of_path(storage) as u32 && storage.sun_path[0] != 0).then(|| {
+                    // The -1 is for the terminating null.
+                    let path_slice = self.path_bytes(storage, true);
+                    Path::new::<OsStr>(OsStrExt::from_bytes(path_slice))
+                })
+            })
+    }
+
+    /// Returns this address as a slice of bytes representing an abstract address if it is an
+    /// `AF_UNIX` abstract address, otherwise returns `None`.
+    ///
+    /// Abstract addresses are a Linux extension, so this method returns None on all non-Linux
+    /// platforms.
+    pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            self.as_sockaddr_un()
+                .and_then(|storage| {
+                    (storage.sun_path[0] == 0).then(|| {
+                        self.path_bytes(storage, false)
+                    })
+                })
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        None
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -674,7 +674,7 @@ impl SockAddr {
                 self.len() == offset_of_path(storage) as u32
                     // On some non-linux platforms a zeroed path is returned for unnamed.
                     // Abstract addresses only exist on Linux.
-                    || (cfg!(not(any(target_os = "linux", target_os = "android")))
+                    || (cfg!(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))
                     && storage.sun_path[0] == 0)
             })
             .unwrap_or_default()
@@ -724,14 +724,14 @@ impl SockAddr {
     /// Abstract addresses are a Linux extension, so this method returns None on all non-Linux
     /// platforms.
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia"))]
         {
             self.as_sockaddr_un().and_then(|storage| {
                 (self.len() > offset_of_path(storage) as u32 && storage.sun_path[0] == 0)
                     .then(|| self.path_bytes(storage, false))
             })
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))]
         None
     }
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -686,7 +686,7 @@ impl SockAddr {
         self.is_unix().then(|| {
             // SAFETY: if local, i.e. the `ss_family` field is `AF_UNIX` then storage must be a
             // `sockaddr_un`.
-            unsafe { &*ptr::addr_of!(self.storage).cast::<libc::sockaddr_un>() }
+            unsafe { &*self.as_ptr().cast::<libc::sockaddr_un>() }
         })
     }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -730,7 +730,7 @@ impl SockAddr {
         {
             self.as_sockaddr_un()
                 .and_then(|storage| {
-                    (storage.sun_path[0] == 0).then(|| {
+                    (self.len() > offset_of_path(storage) as u32 && storage.sun_path[0] == 0).then(|| {
                         self.path_bytes(storage, false)
                     })
                 })

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -710,7 +710,7 @@ impl SockAddr {
         // Where the 1 is either a terminating null if we have a pathname address, or the initial
         // null byte, if it's an abstract name address. In the latter case, the path bytes start
         // after the initial null byte, hence the `offset`.
-        // There is no safe way to convert a `&[i8]` ot `&[u8]`
+        // There is no safe way to convert a `&[i8]` to `&[u8]`
         unsafe {
             slice::from_raw_parts(
                 (storage.sun_path.as_ptr() as *const u8).offset(abstract_name as isize),

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -675,6 +675,7 @@ impl SockAddr {
                     // On some non-linux platforms a zeroed path is returned for unnamed.
                     // Abstract addresses only exist on Linux.
                     // NOTE: although Fuchsia does define `AF_UNIX` it's not actually implemented.
+                    // See https://github.com/rust-lang/socket2/pull/403#discussion_r1123557978
                     || (cfg!(not(any(target_os = "linux", target_os = "android")))
                     && storage.sun_path[0] == 0)
             })
@@ -738,6 +739,7 @@ impl SockAddr {
     /// platforms.
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
         // NOTE: although Fuchsia does define `AF_UNIX` it's not actually implemented.
+        // See https://github.com/rust-lang/socket2/pull/403#discussion_r1123557978
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             self.as_sockaddr_un().and_then(|storage| {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -674,7 +674,8 @@ impl SockAddr {
                 self.len() == offset_of_path(storage) as u32
                     // On some non-linux platforms a zeroed path is returned for unnamed.
                     // Abstract addresses only exist on Linux.
-                    || (cfg!(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))
+                    // NOTE: although Fuchsia does define `AF_UNIX` it's not actually implemented.
+                    || (cfg!(not(any(target_os = "linux", target_os = "android")))
                     && storage.sun_path[0] == 0)
             })
             .unwrap_or_default()
@@ -736,14 +737,15 @@ impl SockAddr {
     /// Abstract addresses are a Linux extension, so this method returns `None` on all non-Linux
     /// platforms.
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia"))]
+        // NOTE: although Fuchsia does define `AF_UNIX` it's not actually implemented.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             self.as_sockaddr_un().and_then(|storage| {
                 (self.len() > offset_of_path(storage) as u32 && storage.sun_path[0] == 0)
                     .then(|| self.path_bytes(storage, true))
             })
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         None
     }
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -95,7 +95,7 @@ pub(crate) use libc::IPPROTO_SCTP;
 pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
 // Used in `SockAddr`.
 pub(crate) use libc::{
-    sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t,
+    sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_un, sockaddr_storage, socklen_t,
 };
 // Used in `RecvFlags`.
 #[cfg(not(target_os = "redox"))]
@@ -570,7 +570,7 @@ impl<'a> MaybeUninitSlice<'a> {
 }
 
 /// Returns the offset of the `sun_path` member of the passed unix socket address.
-pub(crate) fn offset_of_path(storage: &libc::sockaddr_un) -> usize {
+pub(crate) fn offset_of_path(storage: &sockaddr_un) -> usize {
     let base = storage as *const _ as usize;
     let path = ptr::addr_of!(storage.sun_path) as usize;
     path - base
@@ -582,7 +582,7 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     // SAFETY: a `sockaddr_storage` of all zeros is valid.
     let mut storage = unsafe { mem::zeroed::<sockaddr_storage>() };
     let len = {
-        let storage = unsafe { &mut *ptr::addr_of_mut!(storage).cast::<libc::sockaddr_un>() };
+        let storage = unsafe { &mut *ptr::addr_of_mut!(storage).cast::<sockaddr_un>() };
 
         let bytes = path.as_os_str().as_bytes();
         let too_long = match bytes.first() {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -176,7 +176,10 @@ fn socket_address_unix_unnamed() {
 }
 
 #[test]
-#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "fuchsia"), feature = "all"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "android", target_os = "fuchsia"),
+    feature = "all"
+))]
 fn socket_address_unix_abstract_namespace() {
     let path = "\0h".repeat(108 / 2);
     let addr = SockAddr::unix(&path).unwrap();
@@ -185,7 +188,8 @@ fn socket_address_unix_abstract_namespace() {
         std::mem::size_of::<libc::sockaddr_un>()
     );
     assert!(!addr.is_unnamed());
-    assert_eq!(addr.as_abstract_namespace(), Some(path.as_bytes()));
+    // The first byte is the opening null bytes of an abstract address, should not be included.
+    assert_eq!(addr.as_abstract_namespace(), Some(&path.as_bytes()[1..]));
     assert!(addr.as_pathname().is_none());
     assert!(!addr.is_unnamed());
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -176,10 +176,7 @@ fn socket_address_unix_unnamed() {
 }
 
 #[test]
-#[cfg(all(
-    any(target_os = "linux", target_os = "android"),
-    feature = "all"
-))]
+#[cfg(all(any(target_os = "linux", target_os = "android"), feature = "all"))]
 fn socket_address_unix_abstract_namespace() {
     let path = "\0h".repeat(108 / 2);
     let addr = SockAddr::unix(&path).unwrap();

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -38,6 +38,7 @@ use std::num::NonZeroUsize;
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
+#[cfg(unix)]
 use std::path::Path;
 use std::str;
 use std::thread;

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -177,7 +177,7 @@ fn socket_address_unix_unnamed() {
 
 #[test]
 #[cfg(all(
-    any(target_os = "linux", target_os = "android", target_os = "fuchsia"),
+    any(target_os = "linux", target_os = "android"),
     feature = "all"
 ))]
 fn socket_address_unix_abstract_namespace() {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -38,11 +38,11 @@ use std::num::NonZeroUsize;
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
+use std::path::Path;
 use std::str;
 use std::thread;
 use std::time::Duration;
 use std::{env, fs};
-use std::path::Path;
 
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::{GetHandleInformation, HANDLE_FLAG_INHERIT};
@@ -184,10 +184,7 @@ fn socket_address_unix_abstract_namespace() {
         std::mem::size_of::<libc::sockaddr_un>()
     );
     assert!(addr.is_unnamed());
-    assert_eq!(
-        addr.as_abstract_namespace(),
-        Some(path.as_bytes())
-    );
+    assert_eq!(addr.as_abstract_namespace(), Some(path.as_bytes()));
     assert!(addr.as_pathname().is_none());
     assert!(!addr.is_unnamed());
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -176,7 +176,7 @@ fn socket_address_unix_unnamed() {
 }
 
 #[test]
-#[cfg(all(any(target_os = "linux", target_os = "android"), feature = "all"))]
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "fuchsia"), feature = "all"))]
 fn socket_address_unix_abstract_namespace() {
     let path = "\0h".repeat(108 / 2);
     let addr = SockAddr::unix(&path).unwrap();

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -183,7 +183,7 @@ fn socket_address_unix_abstract_namespace() {
         addr.len() as usize,
         std::mem::size_of::<libc::sockaddr_un>()
     );
-    assert!(addr.is_unnamed());
+    assert!(!addr.is_unnamed());
     assert_eq!(addr.as_abstract_namespace(), Some(path.as_bytes()));
     assert!(addr.as_pathname().is_none());
     assert!(!addr.is_unnamed());


### PR DESCRIPTION
Following #332, currently unix only. Should this interface also be made available on Windows?

This PR adds to `SockAddr` methods to get the path of the unix socket address on unix.
It also adds the new methods to the tests.