### PR TITLE
Fix compilation on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
+    - uses: taiki-e/install-action@cargo-hack
     - name: Run tests
       run: cargo hack test --feature-powerset && cargo hack test --feature-powerset --release
 
@@ -68,8 +67,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
+    - uses: taiki-e/install-action@cargo-hack
     - name: Install Target
       run: rustup target add ${{ matrix.target }}
     - name: Run check
@@ -87,8 +85,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust nightly
       run: rustup update nightly && rustup default nightly
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
+    - uses: taiki-e/install-action@cargo-hack
     - name: Install Target
       run: rustup target add ${{ matrix.target }}
     - name: Run check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [ master, "v0.3.x" ]
+    branches: [ master, "v0.4.x" ]
   pull_request:
-    branches: [ master, "v0.3.x" ]
+    branches: [ master, "v0.4.x" ]
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 0.4.8
+# 0.4.9
+
+* Fixed compilation on Windows
+  (https://github.com/rust-lang/socket2/pull/409).
+
+# 0.4.8 (yanked)
+
+This release was broken for Windows.
 
 * Add `Socket::peek_sender` (backport)
   (https://github.com/rust-lang/socket2/pull/404).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "socket2"
-version       = "0.4.8"
+version       = "0.4.9"
 authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -32,6 +32,7 @@ use winapi::um::winsock2::{
     self as sock, u_long, POLLERR, POLLHUP, POLLRDNORM, POLLWRNORM, SD_BOTH, SD_RECEIVE, SD_SEND,
     WSAPOLLFD,
 };
+use winapi::um::winsock2::{SOCKET_ERROR, WSAEMSGSIZE, WSAESHUTDOWN};
 
 use crate::{RecvFlags, SockAddr, TcpKeepalive, Type};
 
@@ -469,7 +470,7 @@ pub(crate) fn recv_from(
 pub(crate) fn peek_sender(socket: Socket) -> io::Result<SockAddr> {
     // Safety: `recvfrom` initialises the `SockAddr` for us.
     let ((), sender) = unsafe {
-        SockAddr::try_init(|storage, addrlen| {
+        SockAddr::init(|storage, addrlen| {
             let res = syscall!(
                 recvfrom(
                     socket,


### PR DESCRIPTION
This was cherry-pick picked from the v0.5 branch, but never compiled
properly due changed made to v0.5. Combine that with a broken CI, which
we didn't know about, and you've got a broken v0.4.8 release.

Fixes #408 