### PR TITLE
Add support for 'all' feature on QNX Neutrino for v0.4.x

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -234,7 +234,8 @@ impl From<SocketAddrV4> for SockAddr {
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
-                target_os = "openbsd"
+                target_os = "openbsd",
+                target_os = "nto"
             ))]
             sin_len: 0,
         };
@@ -273,7 +274,8 @@ impl From<SocketAddrV6> for SockAddr {
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
-                target_os = "openbsd"
+                target_os = "openbsd",
+                target_os = "nto"
             ))]
             sin6_len: 0,
             #[cfg(any(target_os = "solaris", target_os = "illumos"))]


### PR DESCRIPTION
Hi there,

I saw as part of #381 it was mentioned that the v0.4.x branch is not taking PRs, so apologies if this is not appropriate. When those changes were backported these `target_os` flags were not applied (I presume as the function signatures are totally different in master) which prevents compilation on 0.4 branches.

Not sure what the best way to resolve is - recommendations welcome :smile:

CC: @flba-eb @gh-tr