### PR TITLE
Add SockAddr::as_unix

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -741,8 +741,17 @@ impl SockAddr {
         }
     }
 
-    /// Returns this address as a `Path` reference if it is an `AF_UNIX` pathname address, otherwise
-    /// returns `None`.
+    /// Returns this address as Unix `SocketAddr` if it is an `AF_UNIX` pathname
+    /// address, otherwise returns `None`.
+    pub fn as_unix(&self) -> Option<std::os::unix::net::SocketAddr> {
+        let path = self.as_pathname()?;
+        // SAFETY: we can represent this as a valid pathname, then so can the
+        // standard library.
+        Some(std::os::unix::net::SocketAddr::from_pathname(path).unwrap())
+    }
+
+    /// Returns this address as a `Path` reference if it is an `AF_UNIX`
+    /// pathname address, otherwise returns `None`.
     pub fn as_pathname(&self) -> Option<&Path> {
         self.as_sockaddr_un().and_then(|storage| {
             (self.len() > offset_of_path(storage) as u32 && storage.sun_path[0] != 0).then(|| {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -155,6 +155,8 @@ fn socket_address_unix() {
         assert!(!addr.is_unnamed());
         assert_eq!(addr.as_pathname(), Some(Path::new(string)));
         assert_eq!(addr.as_abstract_namespace(), None);
+        let unix = addr.as_unix().unwrap();
+        assert_eq!(addr.as_pathname(), unix.as_pathname());
     }
 }
 
@@ -172,6 +174,7 @@ fn socket_address_unix_unnamed() {
         assert!(addr.is_unnamed());
         assert_eq!(addr.as_pathname(), None);
         assert_eq!(addr.as_abstract_namespace(), None);
+        assert!(addr.as_unix().is_none());
     }
 }
 


### PR DESCRIPTION
Returns the SocketAddr type used by the standard library for Unix sockets.