### PR TITLE
Add v4 and v6 versions of bind_device_by_index.

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1833,6 +1833,33 @@ impl crate::Socket {
         .map(|_| ())
     }
 
+    /// This method is deprecated, use [`crate::Socket::bind_device_by_index_v4`].
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )))
+    )]
+    #[deprecated = "Use `Socket::device_index_v4` instead"]
+    pub fn bind_device_by_index(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
+        self.bind_device_by_index_v4(interface)
+    }
+
     /// Sets the value for `IP_BOUND_IF` option on this socket.
     ///
     /// If a socket is bound to an interface, only packets received from that
@@ -1864,9 +1891,45 @@ impl crate::Socket {
             )
         )))
     )]
-    pub fn bind_device_by_index(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
+    pub fn bind_device_by_index_v4(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
         let index = interface.map_or(0, NonZeroU32::get);
         unsafe { setsockopt(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF, index) }
+    }
+
+    /// Sets the value for `IPV6_BOUND_IF` option on this socket.
+    ///
+    /// If a socket is bound to an interface, only packets received from that
+    /// particular interface are processed by the socket.
+    ///
+    /// If `interface` is `None`, the binding is removed. If the `interface`
+    /// index is not valid, an error is returned.
+    ///
+    /// One can use [`libc::if_nametoindex`] to convert an interface alias to an
+    /// index.
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )))
+    )]
+    pub fn bind_device_by_index_v6(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
+        let index = interface.map_or(0, NonZeroU32::get);
+        unsafe { setsockopt(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF, index) }
     }
 
     /// Gets the value for `IP_BOUND_IF` option on this socket, i.e. the index
@@ -1895,9 +1958,69 @@ impl crate::Socket {
             )
         )))
     )]
-    pub fn device_index(&self) -> io::Result<Option<NonZeroU32>> {
+    pub fn device_index_v4(&self) -> io::Result<Option<NonZeroU32>> {
         let index =
             unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF)? };
+        Ok(NonZeroU32::new(index))
+    }
+
+    /// This method is deprecated, use [`crate::Socket::device_index_v4`].
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )))
+    )]
+    #[deprecated = "Use `Socket::device_index_v4` instead"]
+    pub fn device_index(&self) -> io::Result<Option<NonZeroU32>> {
+        self.device_index_v4()
+    }
+
+    /// Gets the value for `IPV6_BOUND_IF` option on this socket, i.e. the index
+    /// for the interface to which the socket is bound.
+    ///
+    /// Returns `None` if the socket is not bound to any interface, otherwise
+    /// returns an interface index.
+    #[cfg(all(
+        feature = "all",
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "all",
+            any(
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )))
+    )]
+    pub fn device_index_v6(&self) -> io::Result<Option<NonZeroU32>> {
+        let index = unsafe {
+            getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF)?
+        };
         Ok(NonZeroU32::new(index))
     }
 


### PR DESCRIPTION
I've added IPvX versioned functions for `bind_device_by_index` and deprecated the original, as discussed in #413. 

I've added a change log entry (and thus tentatively declaring a new verison), but I'm unsure if that's the correct thing to do here.