### PR TITLE
Haiku: fix build as IP_RECVTOS does not exist (v0.4.x)

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1448,6 +1448,7 @@ impl Socket {
     #[cfg(not(any(
         target_os = "dragonfly",
         target_os = "fuchsia",
+        target_os = "haiku",
         target_os = "illumos",
         target_os = "netbsd",
         target_os = "openbsd",
@@ -1479,6 +1480,7 @@ impl Socket {
     #[cfg(not(any(
         target_os = "dragonfly",
         target_os = "fuchsia",
+        target_os = "haiku",
         target_os = "illumos",
         target_os = "netbsd",
         target_os = "openbsd",


### PR DESCRIPTION
This is a backport of https://github.com/rust-lang/socket2/pull/369 / commit https://github.com/rust-lang/socket2/commit/ed233839be976d07f463ac3eb4dc0d6e19e333ab