### PR TITLE
Add support for receiving ancillary data

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -442,6 +442,29 @@ impl Socket {
         sys::recv(self.as_raw(), buf, flags)
     }
 
+    /// Receives normal and ancillary data on the socket from the remote address to which it is
+    /// connected by setting the `msg_control` field with syscall recvmsg.
+    ///
+    /// In addition to the data received with [`recv`], this method also returns ancillary data.
+    /// To be noted that the ancillary data is not associated with out-of-band (OOB) data.
+    ///
+    /// [`recv`]: Socket::recv
+    #[doc = man_links!(recvmsg(2))]
+    #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "redox")))]
+    pub fn recv_with_ancillary_data(
+        &self,
+        buf: &mut [MaybeUninit<u8>],
+        ancillary_data: &mut [MaybeUninit<u8>],
+    ) -> io::Result<(usize, RecvFlags)> {
+        sys::recv_vectored_with_ancillary_data(
+            self.as_raw(),
+            &mut [MaybeUninitSlice::new(buf)],
+            ancillary_data,
+            0,
+        )
+    }
+
     /// Receives data on the socket from the remote address to which it is
     /// connected. Unlike [`recv`] this allows passing multiple buffers.
     ///
@@ -496,6 +519,20 @@ impl Socket {
         flags: c_int,
     ) -> io::Result<(usize, RecvFlags)> {
         sys::recv_vectored(self.as_raw(), bufs, flags)
+    }
+
+    /// Identical to [`recv_with_ancillary_data`] but allows passing multiple buffers and flags.
+    ///
+    /// [`recv_with_ancillary_data`]: Socket::recv_with_ancillary_data
+    #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "redox")))]
+    pub fn recv_vectored_with_ancillary_data_and_flags(
+        &self,
+        bufs: &mut [MaybeUninitSlice<'_>],
+        ancillary_data: &mut [MaybeUninit<u8>],
+        flags: c_int,
+    ) -> io::Result<(usize, RecvFlags)> {
+        sys::recv_vectored_with_ancillary_data(self.as_raw(), bufs, ancillary_data, flags)
     }
 
     /// Receives data on the socket from the remote adress to which it is

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -593,6 +593,46 @@ fn out_of_band() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
+fn recv_ancillary_data() {
+    use libc::setsockopt;
+
+    let (socket_a, socket_b) = udp_pair_connected();
+    let enabled = 1 as u32;
+    let ret = unsafe {
+        setsockopt(
+            socket_b.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVPKTINFO,
+            &enabled as *const u32 as *const libc::c_void,
+            mem::size_of::<u32>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(ret, 0);
+
+    let sent = socket_a.send(DATA).unwrap();
+    assert_eq!(sent, DATA.len());
+
+    let mut buf = [MaybeUninit::<u8>::uninit(); 16];
+    let mut ancillary = [MaybeUninit::<u8>::uninit(); 128];
+    let (received, _) = socket_b
+        .recv_with_ancillary_data(&mut buf, &mut ancillary)
+        .unwrap();
+    assert_eq!(received, DATA.len());
+    assert_eq!(unsafe { assume_init(&buf[..received]) }, DATA);
+
+    let ancillary = unsafe { assume_init(&ancillary[..]) };
+    let cmsg_len = ancillary[0..core::mem::size_of::<libc::size_t>()]
+        .try_into()
+        .map(usize::from_le_bytes)
+        .unwrap();
+    assert_eq!(
+        cmsg_len,
+        core::mem::size_of::<libc::cmsghdr>() + core::mem::size_of::<libc::in6_pktinfo>()
+    );
+}
+
+#[test]
 #[cfg(not(target_os = "redox"))] // cfg of `udp_pair_unconnected()`
 fn udp_peek_sender() {
     let (socket_a, socket_b) = udp_pair_unconnected();


### PR DESCRIPTION
Two new methods are added in order to receive ancillary data along with normal data. The methods are `recv_with_ancillary_data` and `recv_vectored_with_ancillary_data_and_flags`. The former is easier to use, while the latter provides the flexibility.

The implementation includes changes to the `recvmsg` function in the `sys/unix.rs` file to handle the ancillary data.

A new test case is also added to test the `recv_with_ancillary_data` method.