### PR TITLE
Add Socket::{send,recv}msg and MsgHdr

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -205,12 +205,6 @@ impl SockAddr {
         self.storage.ss_family == AF_UNIX as sa_family_t
     }
 
-    /// Returns a raw pointer to the address storage.
-    #[cfg(all(unix, not(target_os = "redox")))]
-    pub(crate) const fn as_storage_ptr(&self) -> *const sockaddr_storage {
-        &self.storage
-    }
-
     /// Returns this address as a `SocketAddr` if it is in the `AF_INET` (IPv4)
     /// or `AF_INET6` (IPv6) family, otherwise returns `None`.
     pub fn as_socket(&self) -> Option<SocketAddr> {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use crate::sys::{self, c_int, getsockopt, setsockopt, Bool};
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
 #[cfg(not(target_os = "redox"))]
-use crate::{MaybeUninitSlice, RecvFlags};
+use crate::{MaybeUninitSlice, MsgHdr, RecvFlags};
 
 /// Owned wrapper around a system socket.
 ///
@@ -724,6 +724,14 @@ impl Socket {
         flags: c_int,
     ) -> io::Result<usize> {
         sys::send_to_vectored(self.as_raw(), bufs, addr, flags)
+    }
+
+    /// Send a message on a socket using a message structure.
+    #[doc = man_links!(sendmsg(2))]
+    #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(not(target_os = "redox"))))]
+    pub fn sendmsg(&self, msg: &MsgHdr<'_, '_, '_>, flags: sys::c_int) -> io::Result<usize> {
+        sys::sendmsg(self.as_raw(), msg, flags)
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -642,6 +642,33 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
     Ok(unsafe { SockAddr::new(storage, len as socklen_t) })
 }
 
+// Used in `MsgHdr`.
+#[cfg(not(target_os = "redox"))]
+pub(crate) use libc::msghdr;
+
+#[cfg(not(target_os = "redox"))]
+pub(crate) fn set_msghdr_name(msg: &mut msghdr, name: &SockAddr) {
+    msg.msg_name = name.as_ptr().cast_mut().cast();
+    msg.msg_namelen = name.len();
+}
+
+#[cfg(not(target_os = "redox"))]
+pub(crate) fn set_msghdr_iov(msg: &mut msghdr, ptr: *mut libc::iovec, len: usize) {
+    msg.msg_iov = ptr;
+    msg.msg_iovlen = len as _;
+}
+
+#[cfg(not(target_os = "redox"))]
+pub(crate) fn set_msghdr_control(msg: &mut msghdr, ptr: *mut libc::c_void, len: usize) {
+    msg.msg_control = ptr;
+    msg.msg_controllen = len as _;
+}
+
+#[cfg(not(target_os = "redox"))]
+pub(crate) fn set_msghdr_flags(msg: &mut msghdr, flags: libc::c_int) {
+    msg.msg_flags = flags;
+}
+
 /// Unix only API.
 impl SockAddr {
     /// Constructs a `SockAddr` with the family `AF_VSOCK` and the provided CID/port.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1831,8 +1831,8 @@ impl crate::Socket {
     /// Sets the value for the `SO_SETFIB` option on this socket.
     ///
     /// Bind socket to the specified forwarding table (VRF) on a FreeBSD.
-    #[cfg(all(feature = "all", any(target_os = "freebsd")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", any(target_os = "freebsd")))))]
+    #[cfg(all(feature = "all", target_os = "freebsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "freebsd"))))]
     pub fn set_fib(&self, fib: u32) -> io::Result<()> {
         syscall!(setsockopt(
             self.as_raw(),
@@ -2435,8 +2435,8 @@ impl crate::Socket {
     /// Therefore, there is no corresponding `set` helper.
     ///
     /// For more information about this option, see [Linux patch](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5daab9db7b65df87da26fd8cfa695fb9546a1ddb)
-    #[cfg(all(feature = "all", any(target_os = "linux")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", any(target_os = "linux")))))]
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "linux"))))]
     pub fn cookie(&self) -> io::Result<u64> {
         unsafe { getsockopt::<libc::c_ulonglong>(self.as_raw(), libc::SOL_SOCKET, libc::SO_COOKIE) }
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1064,7 +1064,7 @@ pub(crate) fn send_to_vectored(
 }
 
 #[cfg(not(target_os = "redox"))]
-fn sendmsg(fd: Socket, msg: &MsgHdr<'_, '_, '_>, flags: c_int) -> io::Result<usize> {
+pub(crate) fn sendmsg(fd: Socket, msg: &MsgHdr<'_, '_, '_>, flags: c_int) -> io::Result<usize> {
     syscall!(sendmsg(fd, &msg.inner, flags)).map(|n| n as usize)
 }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -187,6 +187,28 @@ impl<'a> MaybeUninitSlice<'a> {
     }
 }
 
+// Used in `MsgHdr`.
+pub(crate) use windows_sys::Win32::Networking::WinSock::WSAMSG as msghdr;
+
+pub(crate) fn set_msghdr_name(msg: &mut msghdr, name: &SockAddr) {
+    msg.name = name.as_ptr().cast_mut().cast();
+    msg.namelen = name.len();
+}
+
+pub(crate) fn set_msghdr_iov(msg: &mut msghdr, ptr: *mut WSABUF, len: usize) {
+    msg.lpBuffers = ptr;
+    msg.dwBufferCount = len as _;
+}
+
+pub(crate) fn set_msghdr_control(msg: &mut msghdr, ptr: *mut u8, len: usize) {
+    msg.Control.buf = ptr;
+    msg.Control.len = len as u32;
+}
+
+pub(crate) fn set_msghdr_flags(msg: &mut msghdr, flags: c_int) {
+    msg.dwFlags = flags as u32;
+}
+
 fn init() {
     static INIT: Once = Once::new();
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -705,6 +705,24 @@ fn send_from_recv_to_vectored() {
 
 #[test]
 #[cfg(not(target_os = "redox"))]
+fn sendmsg() {
+    let (socket_a, socket_b) = udp_pair_unconnected();
+
+    const DATA: &[u8] = b"Hello, World!";
+
+    let bufs = &[IoSlice::new(DATA)];
+    let addr_b = socket_b.local_addr().unwrap();
+    let msg = socket2::MsgHdr::new().with_addr(&addr_b).with_buffers(bufs);
+    let sent = socket_a.sendmsg(&msg, 0).unwrap();
+    assert_eq!(sent, DATA.len());
+
+    let mut buf = Vec::with_capacity(DATA.len() + 1);
+    let received = socket_b.recv(buf.spare_capacity_mut()).unwrap();
+    assert_eq!(received, DATA.len());
+}
+
+#[test]
+#[cfg(not(target_os = "redox"))]
 fn recv_vectored_truncated() {
     let (socket_a, socket_b) = udp_pair_connected();
 


### PR DESCRIPTION
This adds wrappers around `sendmsg(2)` and `recvmsg(2)`.