### PR TITLE
Assign ss_len if it exists.

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -285,6 +285,23 @@ impl From<SocketAddrV4> for SockAddr {
             storage.sin_zero = Default::default();
             mem::size_of::<sockaddr_in>() as socklen_t
         };
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "hermit",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "nto",
+            target_os = "openbsd",
+            target_os = "tvos",
+            target_os = "vxworks",
+            target_os = "watchos",
+        ))]
+        {
+            storage.ss_len = len as u8;
+        }
         SockAddr { storage, len }
     }
 }
@@ -311,6 +328,23 @@ impl From<SocketAddrV6> for SockAddr {
             }
             mem::size_of::<sockaddr_in6>() as socklen_t
         };
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "haiku",
+            target_os = "hermit",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "nto",
+            target_os = "openbsd",
+            target_os = "tvos",
+            target_os = "vxworks",
+            target_os = "watchos",
+        ))]
+        {
+            storage.ss_len = len as u8;
+        }
         SockAddr { storage, len }
     }
 }


### PR DESCRIPTION
Fixes #468 

I don't remove `len` field because:

* `socklen_t` is larger than `u8`.
* It will introduce more platform-specific code.
* Usual socket methods (at least on macOS) don't check `ss_len`. We still need another field to pass in and out.