### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,15 @@
 * Support for AIX
   (https://github.com/rust-lang/socket2/pull/351).
 
+# 0.4.10
+
+* Fixed compilation with the `all` on QNX Neutrino
+  (https://github.com/rust-lang/socket2/pull/419).
+* Add support for ESP-IDF
+  (https://github.com/rust-lang/socket2/pull/455).
+* Add support for Vita
+  (https://github.com/rust-lang/socket2/pull/475).
+
 # 0.4.9
 
 * Fixed compilation on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.5
+
+* Add support for Vita
+  (https://github.com/rust-lang/socket2/pull/465).
+
 # 0.5.4
 
 * Deprecated `Socket::(bind_)device_by_index`, replaced by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "socket2"
-version       = "0.5.4"
+version       = "0.5.5"
 authors       = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>"


### PR DESCRIPTION
Includes the changelog from https://github.com/rust-lang/socket2/pull/476.