### PR TITLE
Haiku fixes for IP_RECVTOS and IP_TOS

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1487,6 +1487,7 @@ impl Socket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "haiku",
     )))]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
         unsafe { setsockopt(self.as_raw(), sys::IPPROTO_IP, sys::IP_TOS, tos as c_int) }
@@ -1505,6 +1506,7 @@ impl Socket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "haiku",
     )))]
     pub fn tos(&self) -> io::Result<u32> {
         unsafe {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -152,6 +152,7 @@ pub(crate) use libc::IP_RECVTOS;
     target_os = "fuchsia",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "haiku",
     target_os = "illumos",
 )))]
 pub(crate) use libc::IP_TOS;


### PR DESCRIPTION
Still a problem when trying to build/install cargo-c on Haiku, related to: https://github.com/rust-lang/socket2/issues/302
(looks some part for IP_RECVTOS has been added already, so this adds the missing parts)