### PR TITLE
Update `windows-sys` 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ features = ["all"]
 libc = "0.2.150"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",


### PR DESCRIPTION
This is the first update to the `windows-sys` crate in 8 months.  https://github.com/microsoft/windows-rs/releases/tag/0.52.0