### PR TITLE
Socket option for IP_MULTICAST_ALL & IPV6_MULTICAST_ALL for linux

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1377,6 +1377,43 @@ impl Socket {
         }
     }
 
+    /// Get the value of the `IP_MULTICAST_ALL` option for this socket.
+    ///
+    /// For more information about this option, see [`set_multicast_all_v4`].
+    ///
+    /// [`set_multicast_all_v4`]: Socket::set_multicast_all_v4
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "linux"))))]
+    pub fn multicast_all_v4(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IP, libc::IP_MULTICAST_ALL)
+                .map(|all| all != 0)
+        }
+    }
+
+    /// Set the value of the `IP_MULTICAST_ALL` option for this socket.
+    ///
+    /// This option can be used to modify the delivery policy of
+    /// multicast messages.  The argument is a boolean
+    /// (defaults to true).  If set to true, the socket will receive
+    /// messages from all the groups that have been joined
+    /// globally on the whole system.  Otherwise, it will deliver
+    /// messages only from the groups that have been explicitly
+    /// joined (for example via the `IP_ADD_MEMBERSHIP` option) on
+    /// this particular socket.
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "linux"))))]
+    pub fn set_multicast_all_v4(&self, all: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                sys::IPPROTO_IP,
+                libc::IPV6_MULTICAST_ALL,
+                all as c_int,
+            )
+        }
+    }
+
     /// Get the value of the `IP_MULTICAST_IF` option for this socket.
     ///
     /// For more information about this option, see [`set_multicast_if_v4`].
@@ -1655,6 +1692,43 @@ impl Socket {
                 sys::IPPROTO_IPV6,
                 sys::IPV6_MULTICAST_HOPS,
                 hops as c_int,
+            )
+        }
+    }
+
+    /// Get the value of the `IPV6_MULTICAST_ALL` option for this socket.
+    ///
+    /// For more information about this option, see [`set_multicast_all_v6`].
+    ///
+    /// [`set_multicast_all_v6`]: Socket::set_multicast_all_v6
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "linux"))))]
+    pub fn multicast_all_v6(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IPV6, libc::IPV6_MULTICAST_ALL)
+                .map(|all| all != 0)
+        }
+    }
+
+    /// Set the value of the `IPV6_MULTICAST_ALL` option for this socket.
+    ///
+    /// This option can be used to modify the delivery policy of
+    /// multicast messages.  The argument is a boolean
+    /// (defaults to true).  If set to true, the socket will receive
+    /// messages from all the groups that have been joined
+    /// globally on the whole system.  Otherwise, it will deliver
+    /// messages only from the groups that have been explicitly
+    /// joined (for example via the `IPV6_ADD_MEMBERSHIP` option) on
+    /// this particular socket.
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "all", target_os = "linux"))))]
+    pub fn set_multicast_all_v6(&self, all: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                sys::IPPROTO_IPV6,
+                libc::IPV6_MULTICAST_ALL,
+                all as c_int,
             )
         }
     }


### PR DESCRIPTION
Added socket options for IP_MULTICAST_ALL & IPV6_MULTICAST_ALL which can be used to filter multicast packets received on the socket only from the groups that have been explicitly joined.

Useful when used in combination with SO_REUSEPORT

