### PR TITLE
Fix typo in #485 (set_multicast_all_v4)

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1408,7 +1408,7 @@ impl Socket {
             setsockopt(
                 self.as_raw(),
                 sys::IPPROTO_IP,
-                libc::IPV6_MULTICAST_ALL,
+                libc::IP_MULTICAST_ALL,
                 all as c_int,
             )
         }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1467,6 +1467,11 @@ test!(
     set_tcp_user_timeout(Some(Duration::from_secs(10)))
 );
 
+#[cfg(all(feature = "all", target_os = "linux"))]
+test!(IPv4 multicast_all_v4, set_multicast_all_v4(false));
+#[cfg(all(feature = "all", target_os = "linux"))]
+test!(IPv6 multicast_all_v6, set_multicast_all_v6(false));
+
 #[test]
 #[cfg(not(any(
     target_os = "haiku",


### PR DESCRIPTION
Fixes typo in set_multicast_all_v4 added in #485

added tests