### PR TITLE
Fix compilation error with target_env=ohos

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -325,6 +325,7 @@ type IovLen = usize;
         target_os = "linux",
         any(
             target_env = "musl",
+            target_env = "ohos",
             all(target_env = "uclibc", target_pointer_width = "32")
         )
     ),


### PR DESCRIPTION
OpenHarmony(alias ohos) is tie 3 supported target for rust. see https://github.com/rust-lang/compiler-team/issues/568.

In implementation it sits close to musl instead of bionic and napi instead jni when comparing with android.

Below is copied from ohos sdk:

```
> ag iov_max openharmony/9/native/sysroot/usr/include
openharmony/9/native/sysroot/usr/include/limits.h
50:#define IOV_MAX 1024
162:#define _XOPEN_IOV_MAX          16

openharmony/9/native/sysroot/usr/include/unistd.h
320:#define _SC_IOV_MAX 60
```