### PR TITLE
Add support for sendmmsg/recvmmsg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,14 +732,34 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdrMut<'name, 'bufs, 'control> {
 ///
 /// This wraps `mmsghdr` on Unix. Also see [`MmsgHdrMut`] for the variant used
 /// by `recvmmsg(2)`.
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 pub struct MmsgHdr<'addr, 'bufs, 'control> {
     inner: Vec<sys::mmsghdr>,
     #[allow(clippy::type_complexity)]
     _lifetimes: PhantomData<(&'addr SockAddr, &'bufs IoSlice<'bufs>, &'control [u8])>,
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 impl<'addr, 'bufs, 'control> MmsgHdr<'addr, 'bufs, 'control> {
     /// Create a new `MmsgHdr` with all empty/zero fields.
     #[allow(clippy::new_without_default)]
@@ -792,7 +812,17 @@ impl<'addr, 'bufs, 'control> MmsgHdr<'addr, 'bufs, 'control> {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 impl<'name, 'bufs, 'control> fmt::Debug for MmsgHdr<'name, 'bufs, 'control> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         "MmsgHdr".fmt(fmt)
@@ -803,7 +833,17 @@ impl<'name, 'bufs, 'control> fmt::Debug for MmsgHdr<'name, 'bufs, 'control> {
 ///
 /// This wraps `mmsghdr` on Unix. Also see [`MmsgHdr`] for the variant used by
 /// `sendmmsg(2)`.
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 pub struct MmsgHdrMut<'addr, 'bufs, 'control> {
     inner: Vec<sys::mmsghdr>,
     #[allow(clippy::type_complexity)]
@@ -814,7 +854,17 @@ pub struct MmsgHdrMut<'addr, 'bufs, 'control> {
     )>,
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 impl<'addr, 'bufs, 'control> MmsgHdrMut<'addr, 'bufs, 'control> {
     /// Create a new `MmsgHdrMut` with all empty/zero fields.
     #[allow(clippy::new_without_default)]
@@ -869,7 +919,17 @@ impl<'addr, 'bufs, 'control> MmsgHdrMut<'addr, 'bufs, 'control> {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
 impl<'name, 'bufs, 'control> fmt::Debug for MmsgHdrMut<'name, 'bufs, 'control> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         "MmsgHdrMut".fmt(fmt)

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -21,11 +21,23 @@ use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 use std::time::Duration;
 
 use crate::sys::{self, c_int, getsockopt, setsockopt, Bool};
+#[cfg(all(unix, not(target_os = "redox")))]
+use crate::MsgHdrMut;
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
 #[cfg(not(target_os = "redox"))]
 use crate::{MaybeUninitSlice, MsgHdr, RecvFlags};
-#[cfg(all(unix, not(target_os = "redox")))]
-use crate::{MmsgHdr, MmsgHdrMut, MsgHdrMut};
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "hurd",
+        target_os = "vita",
+        target_os = "illumos",
+        target_vendor = "apple"
+    ))
+))]
+use crate::{MmsgHdr, MmsgHdrMut};
 
 /// Owned wrapper around a system socket.
 ///
@@ -587,8 +599,31 @@ impl Socket {
     }
 
     /// Receive multiple messages in a single call.
-    #[cfg(all(unix, not(target_os = "redox")))]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "redox")))))]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "hurd",
+            target_os = "vita",
+            target_os = "illumos",
+            target_vendor = "apple"
+        ))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "hurd",
+                target_os = "vita",
+                target_os = "illumos",
+                target_vendor = "apple"
+            ))
+        )))
+    )]
     pub fn recv_multiple_from(
         &self,
         msgs: &mut [MaybeUninitSlice<'_>],
@@ -655,8 +690,31 @@ impl Socket {
 
     /// Receive multiple messages from a socket using a message structure.
     #[doc = man_links!(recvmmsg(2))]
-    #[cfg(all(unix, not(target_os = "redox")))]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "redox")))))]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "hurd",
+            target_os = "vita",
+            target_os = "illumos",
+            target_vendor = "apple"
+        ))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "hurd",
+                target_os = "vita",
+                target_os = "illumos",
+                target_vendor = "apple"
+            ))
+        )))
+    )]
     pub fn recvmmsg(
         &self,
         msgs: &mut MmsgHdrMut<'_, '_, '_>,
@@ -766,8 +824,31 @@ impl Socket {
 
     /// Send multiple data to multiple peers listening on `addrs`. Return the amount of bytes
     /// written for each message.
-    #[cfg(all(unix, not(target_os = "redox")))]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "redox")))))]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "hurd",
+            target_os = "vita",
+            target_os = "illumos",
+            target_vendor = "apple"
+        ))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "hurd",
+                target_os = "vita",
+                target_os = "illumos",
+                target_vendor = "apple"
+            ))
+        )))
+    )]
     pub fn send_multiple_to(
         &self,
         msgs: &[IoSlice<'_>],
@@ -787,8 +868,31 @@ impl Socket {
 
     /// Send multiple messages on a socket using a multiple message structure.
     #[doc = man_links!(sendmmsg(2))]
-    #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(not(target_os = "redox"))))]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "hurd",
+            target_os = "vita",
+            target_os = "illumos",
+            target_vendor = "apple"
+        ))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "hurd",
+                target_os = "vita",
+                target_os = "illumos",
+                target_vendor = "apple"
+            ))
+        )))
+    )]
     pub fn sendmmsg(&self, msgs: &MmsgHdr<'_, '_, '_>, flags: sys::c_int) -> io::Result<usize> {
         sys::sendmmsg(self.as_raw(), msgs, flags)
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -587,8 +587,8 @@ impl Socket {
     }
 
     /// Receive multiple messages in a single call.
-    #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(not(target_os = "redox"))))]
+    #[cfg(all(unix, not(target_os = "redox")))]
+    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "redox")))))]
     pub fn recv_multiple_from(
         &self,
         msgs: &mut [MaybeUninitSlice<'_>],
@@ -766,8 +766,8 @@ impl Socket {
 
     /// Send multiple data to multiple peers listening on `addrs`. Return the amount of bytes
     /// written for each message.
-    #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(not(target_os = "redox"))))]
+    #[cfg(all(unix, not(target_os = "redox")))]
+    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "redox")))))]
     pub fn send_multiple_to(
         &self,
         msgs: &[IoSlice<'_>],

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1151,16 +1151,7 @@ pub(crate) fn recvmmsg(
     syscall!(recvmmsg(
         fd,
         msgs.inner.as_mut_ptr(),
-        {
-            #[cfg(target_os = "freebsd")]
-            {
-                msgs.inner.len()
-            }
-            #[cfg(not(target_os = "freebsd"))]
-            {
-                msgs.inner.len() as u32
-            }
-        },
+        msgs.inner.len() as _,
         {
             #[cfg(target_env = "musl")]
             {
@@ -1254,16 +1245,7 @@ pub(crate) fn sendmmsg(fd: Socket, msgs: &MmsgHdr<'_, '_, '_>, flags: c_int) -> 
     syscall!(sendmmsg(
         fd,
         msgs.inner.as_ptr() as *mut _,
-        {
-            #[cfg(target_os = "freebsd")]
-            {
-                msgs.inner.len()
-            }
-            #[cfg(not(target_os = "freebsd"))]
-            {
-                msgs.inner.len() as u32
-            }
-        },
+        msgs.inner.len() as _,
         {
             #[cfg(target_env = "musl")]
             {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1152,16 +1152,7 @@ pub(crate) fn recvmmsg(
         fd,
         msgs.inner.as_mut_ptr(),
         msgs.inner.len() as _,
-        {
-            #[cfg(target_env = "musl")]
-            {
-                flags as u32
-            }
-            #[cfg(not(target_env = "musl"))]
-            {
-                flags
-            }
-        },
+        flags as _,
         ptr::null_mut()
     ))
     .map(|n| n as usize)
@@ -1246,16 +1237,7 @@ pub(crate) fn sendmmsg(fd: Socket, msgs: &MmsgHdr<'_, '_, '_>, flags: c_int) -> 
         fd,
         msgs.inner.as_ptr() as *mut _,
         msgs.inner.len() as _,
-        {
-            #[cfg(target_env = "musl")]
-            {
-                flags as u32
-            }
-            #[cfg(not(target_env = "musl"))]
-            {
-                flags
-            }
-        },
+        flags as _,
     ))
     .map(|n| n as usize)
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1105,7 +1105,16 @@ pub(crate) fn recvmmsg(
     syscall!(recvmmsg(
         fd,
         msgs.inner.as_mut_ptr(),
-        msgs.inner.len() as u32,
+        {
+            #[cfg(target_os = "freebsd")]
+            {
+                msgs.inner.len()
+            }
+            #[cfg(not(target_os = "freebsd"))]
+            {
+                msgs.inner.len() as u32
+            }
+        },
         flags,
         ptr::null_mut()
     ))
@@ -1176,7 +1185,16 @@ pub(crate) fn sendmmsg(fd: Socket, msgs: &MmsgHdr<'_, '_, '_>, flags: c_int) -> 
     syscall!(sendmmsg(
         fd,
         msgs.inner.as_ptr() as *mut _,
-        msgs.inner.len() as u32,
+        {
+            #[cfg(target_os = "freebsd")]
+            {
+                msgs.inner.len()
+            }
+            #[cfg(not(target_os = "freebsd"))]
+            {
+                msgs.inner.len() as u32
+            }
+        },
         flags
     ))
     .map(|n| n as usize)

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -71,8 +71,17 @@ use libc::ssize_t;
 use libc::{in6_addr, in_addr};
 
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
+use crate::{MmsgHdr, MmsgHdrMut};
 #[cfg(not(target_os = "redox"))]
-use crate::{MmsgHdr, MmsgHdrMut, MsgHdr, MsgHdrMut, RecvFlags};
+use crate::{MsgHdr, MsgHdrMut, RecvFlags};
 
 pub(crate) use libc::c_int;
 
@@ -671,8 +680,17 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
 }
 
 // Used in `MsgHdr`.
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
+pub(crate) use libc::mmsghdr;
 #[cfg(not(target_os = "redox"))]
-pub(crate) use libc::{mmsghdr, msghdr};
+pub(crate) use libc::msghdr;
 
 #[cfg(not(target_os = "redox"))]
 pub(crate) fn set_msghdr_name(msg: &mut msghdr, name: &SockAddr) {
@@ -1067,7 +1085,14 @@ pub(crate) fn recvmsg(
     syscall!(recvmsg(fd, &mut msg.inner, flags)).map(|n| n as usize)
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
 pub(crate) fn recv_multiple_from(
     fd: Socket,
     msgs: &mut [crate::MaybeUninitSlice<'_>],
@@ -1096,7 +1121,14 @@ pub(crate) fn recv_multiple_from(
     Ok(rets)
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
 pub(crate) fn recvmmsg(
     fd: Socket,
     msgs: &mut MmsgHdrMut<'_, '_, '_>,
@@ -1174,7 +1206,14 @@ pub(crate) fn sendmsg(fd: Socket, msg: &MsgHdr<'_, '_, '_>, flags: c_int) -> io:
     syscall!(sendmsg(fd, &msg.inner, flags)).map(|n| n as usize)
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
 pub(crate) fn send_multiple_to(
     fd: Socket,
     msgs: &[IoSlice<'_>],
@@ -1189,7 +1228,14 @@ pub(crate) fn send_multiple_to(
         .collect())
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "hurd",
+    target_os = "vita",
+    target_os = "illumos",
+    target_vendor = "apple"
+)))]
 pub(crate) fn sendmmsg(fd: Socket, msgs: &MmsgHdr<'_, '_, '_>, flags: c_int) -> io::Result<usize> {
     syscall!(sendmmsg(
         fd,

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1115,7 +1115,16 @@ pub(crate) fn recvmmsg(
                 msgs.inner.len() as u32
             }
         },
-        flags,
+        {
+            #[cfg(target_env = "musl")]
+            {
+                flags as u32
+            }
+            #[cfg(not(target_env = "musl"))]
+            {
+                flags
+            }
+        },
         ptr::null_mut()
     ))
     .map(|n| n as usize)
@@ -1195,7 +1204,16 @@ pub(crate) fn sendmmsg(fd: Socket, msgs: &MmsgHdr<'_, '_, '_>, flags: c_int) -> 
                 msgs.inner.len() as u32
             }
         },
-        flags
+        {
+            #[cfg(target_env = "musl")]
+            {
+                flags as u32
+            }
+            #[cfg(not(target_env = "musl"))]
+            {
+                flags
+            }
+        },
     ))
     .map(|n| n as usize)
 }


### PR DESCRIPTION
This PR aims to add support for the `sendmmsg`/`recvmmsg` syscalls.

The API exposed here is a bit simplified, where the "user friendly" functions don't expose the scatter/gather stuff (the `_vectored` variants found for `recvmsg`/`sendmsg`). This was not exposed to not blow up the API surface, while keeping the functionality using `MmsgHdr(Mut)` for advanced usages.

Thanks!