### PR TITLE
Add MSG_CONFIRM and MSG_DONTROUTE to RecvFlags

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -573,6 +573,37 @@ impl RecvFlags {
     pub const fn is_out_of_band(self) -> bool {
         self.0 & libc::MSG_OOB != 0
     }
+
+    /// Check if the confirm flag is set.
+    ///
+    /// This is used by SocketCAN to indicate a frame was sent via the
+    /// socket it is received on. This flag can be interpreted as a
+    /// 'transmission confirmation'.
+    ///
+    /// On Unix this corresponds to the `MSG_CONFIRM` flag.
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub const fn is_confirm(self) -> bool {
+        self.0 & libc::MSG_CONFIRM != 0
+    }
+
+    /// Check if the don't route flag is set.
+    ///
+    /// This is used by SocketCAN to indicate a frame was created
+    /// on the local host.
+    ///
+    /// On Unix this corresponds to the `MSG_DONTROUTE` flag.
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub const fn is_dontroute(self) -> bool {
+        self.0 & libc::MSG_DONTROUTE != 0
+    }
 }
 
 #[cfg(not(target_os = "redox"))]
@@ -584,6 +615,10 @@ impl std::fmt::Debug for RecvFlags {
         s.field("is_out_of_band", &self.is_out_of_band());
         #[cfg(not(target_os = "espidf"))]
         s.field("is_truncated", &self.is_truncated());
+        #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+        s.field("is_confirm", &self.is_confirm());
+        #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+        s.field("is_dontroute", &self.is_dontroute());
         s.finish()
     }
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -731,6 +731,10 @@ fn send_from_recv_to_vectored() {
     #[cfg(all(unix, not(target_os = "redox")))]
     assert_eq!(flags.is_out_of_band(), false);
     assert_eq!(flags.is_truncated(), false);
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    assert_eq!(flags.is_confirm(), false);
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    assert_eq!(flags.is_dontroute(), false);
     assert_eq!(
         addr.as_socket_ipv6().unwrap(),
         addr_a.as_socket_ipv6().unwrap()


### PR DESCRIPTION
This is useful when reading from SocketCAN sockets. The MSG_CONFIRM flag is used to indicate a successful transmission of a CAN frame. 

Reference: https://www.kernel.org/doc/html/next/networking/can.html#raw-socket-option-can-raw-join-filters

Is there any reason the raw flags value is not exposed to the user? There might be more drivers that are using non-standard flags to communicate a certain state.