### PR TITLE
Update to FreeBSD 13.2 on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-1
+  image_family: freebsd-13-2
 
 env:
   RUST_BACKTRACE: full


### PR DESCRIPTION
Backport of f5367ea25de76bc45071dd3fa9bfff604b1eacc9.