### PR TITLE
Add `MsgHdrMut::control_len` to get how much of control buffer was filled.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,6 +719,15 @@ impl<'addr, 'bufs, 'control> MsgHdrMut<'addr, 'bufs, 'control> {
     pub fn flags(&self) -> RecvFlags {
         sys::msghdr_flags(&self.inner)
     }
+
+    /// Gets the length of the control buffer.
+    ///
+    /// Can be used to determine how much, if any, of the control buffer was filled by `recvmsg`.
+    ///
+    /// Corresponds to `msg_controllen` on Unix and `Control.len` on Windows.
+    pub fn control_len(&self) -> usize {
+        sys::msghdr_control_len(&self.inner)
+    }
 }
 
 #[cfg(not(target_os = "redox"))]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -738,6 +738,11 @@ pub(crate) fn msghdr_flags(msg: &msghdr) -> RecvFlags {
     RecvFlags(msg.msg_flags)
 }
 
+#[cfg(not(target_os = "redox"))]
+pub(crate) fn msghdr_control_len(msg: &msghdr) -> usize {
+    msg.msg_controllen as _
+}
+
 /// Unix only API.
 impl SockAddr {
     /// Constructs a `SockAddr` with the family `AF_VSOCK` and the provided CID/port.

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -215,6 +215,10 @@ pub(crate) fn msghdr_flags(msg: &msghdr) -> RecvFlags {
     RecvFlags(msg.dwFlags as c_int)
 }
 
+pub(crate) fn msghdr_control_len(msg: &msghdr) -> usize {
+    msg.Control.len as _
+}
+
 fn init() {
     static INIT: Once = Once::new();
 


### PR DESCRIPTION
As stated in the title, this exposes the underlying `msg_controllen`/`Control.len` field for `MsgHdrMut`, which is necessary to figure out how many bytes, if any, were filled in the control buffer.