### PR TITLE
fix typos

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -258,7 +258,7 @@ impl SockAddr {
     /// Returns the initialised storage bytes.
     fn as_bytes(&self) -> &[u8] {
         // SAFETY: `self.storage` is a C struct which can always be treated a
-        // slice of bytes. Futhermore we ensure we don't read any unitialised
+        // slice of bytes. Furthermore, we ensure we don't read any unitialised
         // bytes by using `self.len`.
         unsafe { std::slice::from_raw_parts(self.as_ptr().cast(), self.len as usize) }
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1053,7 +1053,7 @@ impl Socket {
 
     /// Set value for the `SO_REUSEADDR` option on this socket.
     ///
-    /// This indicates that futher calls to `bind` may allow reuse of local
+    /// This indicates that further calls to `bind` may allow reuse of local
     /// addresses. For IPv4 sockets this means that a socket may bind even when
     /// there's a socket already listening on this port.
     pub fn set_reuse_address(&self, reuse: bool) -> io::Result<()> {
@@ -2143,7 +2143,7 @@ impl Read for Socket {
     #[cfg(not(target_os = "redox"))]
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
-        // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
+        // same layout, that of `iovec`/`WSABUF`. Furthermore, `recv_vectored`
         // promises to not write unitialised bytes to the `bufs` and pass it
         // directly to the `recvmsg` system call, so this is safe.
         let bufs = unsafe { &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [MaybeUninitSlice<'_>]) };


### PR DESCRIPTION
Fixes minor errors in comments and docs. Specifically, this commit corrects "Futhermore" to "Furthermore" and adds a comma after uses of "Furthermore" as an introductory phrase.