### PR TITLE
Merge Check, CheckTier3, Docs and DocsTier3 CI jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-2
+  image: freebsd-14-1-release-amd64
 
 env:
   RUST_BACKTRACE: full

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-14-1-release-amd64
+  image: freebsd-13-2-release-amd64
 
 env:
   RUST_BACKTRACE: full
@@ -7,7 +7,7 @@ env:
 task:
   name: FreeBSD
   setup_script:
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile minimal
   cargo_cache:
     folder: $HOME/.cargo/registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,15 +60,12 @@ jobs:
           - aarch64-apple-darwin
           - aarch64-apple-ios
           - aarch64-apple-tvos
-          - aarch64-apple-visionos
           - aarch64-apple-watchos
           - aarch64-linux-android
           - aarch64-unknown-freebsd
-          - aarch64-unknown-hermit
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - aarch64-unknown-netbsd
-          - aarch64-unknown-nto-qnx710
           - aarch64-unknown-openbsd
           - aarch64-unknown-redox
           - arm-linux-androideabi
@@ -78,20 +75,19 @@ jobs:
           - i686-linux-android
           - i686-unknown-hurd-gnu
           - i686-unknown-linux-gnu
-          - riscv32imc-esp-espidf
           - sparcv9-sun-solaris
-          - wasm32-wasi
           - x86_64-apple-darwin
           - x86_64-apple-ios
-          - x86_64-pc-nto-qnx710
           - x86_64-pc-solaris
-          - x86_64-pc-windows-gnu
+          # Fails with:
+          # `rror calling dlltool 'x86_64-w64-mingw32-dlltool': No such file or
+          # directory (os error 2)`, build log:
+          # <https://github.com/rust-lang/socket2/actions/runs/9577808331/job/26406752150>.
+          #- x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-unknown-dragonfly
           - x86_64-unknown-freebsd
           - x86_64-unknown-fuchsia
-          - x86_64-unknown-haiku
-          - x86_64-unknown-hermit
           - x86_64-unknown-illumos
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,35 +51,63 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
   Check:
-    name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        target: ["aarch64-apple-ios", "aarch64-linux-android", "x86_64-apple-darwin", "x86_64-unknown-fuchsia", "x86_64-pc-windows-msvc", "x86_64-pc-solaris", "x86_64-unknown-freebsd", "x86_64-unknown-illumos", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-netbsd", "x86_64-unknown-redox", "armv7-linux-androideabi", "i686-linux-android"]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.target }}
-    - uses: taiki-e/install-action@cargo-hack
-    - name: Run check
-      run: cargo hack check --feature-powerset --all-targets --examples --bins --tests --target ${{ matrix.target }}
-  CheckTier3:
-    name: Check
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["armv7-sony-vita-newlibeabihf", "i686-unknown-hurd-gnu"]
+        target:
+          - aarch64-apple-darwin
+          - aarch64-apple-ios
+          - aarch64-apple-tvos
+          - aarch64-apple-visionos
+          - aarch64-apple-watchos
+          - aarch64-linux-android
+          - aarch64-unknown-freebsd
+          - aarch64-unknown-hermit
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-netbsd
+          - aarch64-unknown-nto-qnx710
+          - aarch64-unknown-openbsd
+          - aarch64-unknown-redox
+          - arm-linux-androideabi
+          - arm64_32-apple-watchos
+          - armv7-linux-androideabi
+          - armv7-sony-vita-newlibeabihf
+          - i686-linux-android
+          - i686-unknown-hurd-gnu
+          - i686-unknown-linux-gnu
+          - riscv32imc-esp-espidf
+          - sparcv9-sun-solaris
+          - wasm32-wasi
+          - x86_64-apple-darwin
+          - x86_64-apple-ios
+          - x86_64-pc-nto-qnx710
+          - x86_64-pc-solaris
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-dragonfly
+          - x86_64-unknown-freebsd
+          - x86_64-unknown-fuchsia
+          - x86_64-unknown-haiku
+          - x86_64-unknown-hermit
+          - x86_64-unknown-illumos
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-netbsd
+          - x86_64-unknown-openbsd
+          - x86_64-unknown-redox
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
       with:
-        components: "rust-src"
+        components: rust-src
     - uses: taiki-e/install-action@cargo-hack
-    - name: Run check
-      run: cargo hack check -Z build-std=std,panic_abort --feature-powerset --all-targets --examples --bins --tests --target ${{ matrix.target }}
+    - name: Check build
+      run: cargo hack check -Z build-std=std,panic_abort --feature-powerset --target ${{ matrix.target }}
+    - name: Check docs
+      run: RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc -Z build-std=std,panic_abort --no-deps --all-features --target ${{ matrix.target }}
   Clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -88,31 +116,3 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
-  Docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["aarch64-apple-ios", "aarch64-linux-android", "x86_64-apple-darwin", "x86_64-unknown-fuchsia", "x86_64-pc-windows-msvc", "x86_64-pc-solaris", "x86_64-unknown-freebsd", "x86_64-unknown-illumos", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-netbsd", "x86_64-unknown-redox", "armv7-linux-androideabi", "i686-linux-android"]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly # NOTE: need nightly for `doc_cfg` feature.
-      with:
-        targets: ${{ matrix.target }}
-    - name: Check docs for docs.rs
-      run: RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc --no-deps --all-features --target ${{ matrix.target }}
-  DocsTier3:
-    name: Docs
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["armv7-sony-vita-newlibeabihf", "i686-unknown-hurd-gnu"]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly # NOTE: need nightly for `doc_cfg` feature.
-      with:
-        components: "rust-src"
-    - name: Check docs for docs.rs
-      run: RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc -Z build-std=std,panic_abort --no-deps --all-features --target ${{ matrix.target }}


### PR DESCRIPTION
And expand the amount of targets we check.

Instead of getting the target setup twice, one for the cargo check run and another for cargo doc, do it once and check both.