### PR TITLE
Fix: header_included_v6 is broken on BSD OSes

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1682,7 +1682,17 @@ impl Socket {
     /// For more information about this option, see [`set_header_included`].
     ///
     /// [`set_header_included`]: Socket::set_header_included
-    #[cfg(all(feature = "all", not(any(target_os = "redox", target_os = "espidf"))))]
+    #[cfg(all(
+        feature = "all",
+        not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "openbsd",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd"
+        ))
+    ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(feature = "all", not(any(target_os = "redox", target_os = "espidf")))))
@@ -1706,7 +1716,17 @@ impl Socket {
         any(target_os = "fuchsia", target_os = "illumos", target_os = "solaris"),
         allow(rustdoc::broken_intra_doc_links)
     )]
-    #[cfg(all(feature = "all", not(any(target_os = "redox", target_os = "espidf"))))]
+    #[cfg(all(
+        feature = "all",
+        not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "openbsd",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd"
+        ))
+    ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(all(feature = "all", not(any(target_os = "redox", target_os = "espidf")))))

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1564,7 +1564,17 @@ fn header_included() {
 }
 
 #[test]
-#[cfg(all(feature = "all", not(target_os = "redox")))]
+#[cfg(all(
+    feature = "all",
+    not(any(
+        target_os = "redox",
+        target_os = "espidf",
+        target_os = "openbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd"
+    ))
+))]
 fn header_included_ipv6() {
     let socket = match Socket::new(Domain::IPV6, Type::RAW, None) {
         Ok(socket) => socket,


### PR DESCRIPTION
See  #534

Broken since #518 - looks like BSD operating systems don't support IP_HDRINCL at the IPPROTO_IPV6 socket level like Linux and Windows; this is causing CI to fail.