### PR TITLE
feat: Add UDP GRO option

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -3097,6 +3097,36 @@ impl crate::Socket {
             )
         }
     }
+
+    /// Get the value of the `UDP_GRO` option on this socket.
+    ///
+    /// For more information about this option, see [`set_udp_gro`].
+    ///
+    /// [`set_udp_gro`]: Socket::set_udp_gro
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub fn udp_gro(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.as_raw(), libc::SOL_UDP, libc::UDP_GRO).map(|reuse| reuse != 0)
+        }
+    }
+
+    /// Set value for the `UDP_GRO` option on this socket.
+    ///
+    /// This indicates that the kernel can combine multiple datagrams into a
+    /// single buffer, this needs to be used in combination with [`Self::recvmsg`]
+    /// to get the number of segments in the buffer from the [`MsgHdr`].
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+    )]
+    pub fn set_udp_gro(&self, reuse: bool) -> io::Result<()> {
+        unsafe { setsockopt(self.as_raw(), libc::SOL_UDP, libc::UDP_GRO, reuse as c_int) }
+    }
 }
 
 /// See [`Socket::dccp_available_ccids`].

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1355,6 +1355,12 @@ test!(reuse_address, set_reuse_address(true));
     not(any(windows, target_os = "solaris", target_os = "illumos"))
 ))]
 test!(reuse_port, set_reuse_port(true));
+#[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "all", any(target_os = "android", target_os = "linux"))))
+)]
+test!(udp_gro, set_udp_gro(true));
 #[cfg(all(feature = "all", target_os = "freebsd"))]
 test!(reuse_port_lb, set_reuse_port_lb(true));
 #[cfg(all(feature = "all", unix, not(target_os = "redox")))]


### PR DESCRIPTION
Allows setting UDP_GRO on the socket.

https://www.man7.org/linux/man-pages/man7/udp.7.html

> Enables UDP receive offload.  If enabled, the socket may
              receive multiple datagrams worth of data as a single large
              buffer, together with a cmsg(3) that holds the segment
              size.  This option is the inverse of segmentation offload.
              It reduces receive cost by handling multiple datagrams
              worth of data as a single large packet in the kernel
              receive path, even when that exceeds MTU.  This option
              should not be used in code intended to be portable.