### PR TITLE
Bump `windows-sys` to 0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["all"]
 libc = "0.2.150"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52"
+version = "0.59"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -931,6 +931,7 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
         storage.sun_family = crate::sys::AF_UNIX as sa_family_t;
         // `storage` was initialized to zero above, so the path is
         // already null terminated.
+        let bytes: &[i8] = unsafe { slice::from_raw_parts(bytes.as_ptr().cast(), bytes.len()) }; 
         storage.sun_path[..bytes.len()].copy_from_slice(bytes);
 
         let base = storage as *const _ as usize;


### PR DESCRIPTION
Addresses #558 

Version of the `windows-sys` dependency is updated to `0.59`, the motivation for this is to get the `arm64ec-pc-windows-msvc` build to work.

Added a cast in the `unix_sockaddr` function because the `SOCKADDR_UN` definition has changed, `sun_path` member is now `[i8]`.