### PR TITLE
Enable `IP_BOUND_IF` on illumos and Solaris

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ targets = [
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.150"
+libc = "0.2.171"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1392,25 +1392,31 @@ pub(crate) fn original_dst_ipv6(fd: Socket) -> io::Result<SockAddr> {
 }
 
 // TODO(eliza): use libc's definition on solarish once it merges...
-#[cfg(any(target_os = "illumos", target_os = "solaris",))]
+#[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
 const IP_BOUND_IF: libc::c_int = 0x41;
-#[cfg(any(
-    target_os = "ios",
-    target_os = "visionos",
-    target_os = "macos",
-    target_os = "tvos",
-    target_os = "watchos",
+#[cfg(all(
+    feature = "all",
+    any(
+        target_os = "ios",
+        target_os = "visionos",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
 ))]
 use libc::IP_BOUND_IF;
 
-#[cfg(any(target_os = "illumos", target_os = "solaris",))]
+#[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
 const IPV6_BOUND_IF: libc::c_int = 0x41;
-#[cfg(any(
-    target_os = "ios",
-    target_os = "visionos",
-    target_os = "macos",
-    target_os = "tvos",
-    target_os = "watchos",
+#[cfg(all(
+    feature = "all",
+    any(
+        target_os = "ios",
+        target_os = "visionos",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
 ))]
 use libc::IPV6_BOUND_IF;
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1391,36 +1391,6 @@ pub(crate) fn original_dst_ipv6(fd: Socket) -> io::Result<SockAddr> {
     .map(|(_, addr)| addr)
 }
 
-// TODO: remove this once https://github.com/rust-lang/libc/pull/4287 merges
-#[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
-const IP_BOUND_IF: libc::c_int = 0x41;
-#[cfg(all(
-    feature = "all",
-    any(
-        target_os = "ios",
-        target_os = "visionos",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos",
-    )
-))]
-use libc::IP_BOUND_IF;
-
-// TODO: remove this once https://github.com/rust-lang/libc/pull/4287 merges
-#[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
-const IPV6_BOUND_IF: libc::c_int = 0x41;
-#[cfg(all(
-    feature = "all",
-    any(
-        target_os = "ios",
-        target_os = "visionos",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos",
-    )
-))]
-use libc::IPV6_BOUND_IF;
-
 /// Unix only API.
 impl crate::Socket {
     /// Accept a new incoming connection from this listener.
@@ -1872,7 +1842,7 @@ impl crate::Socket {
     ))]
     pub fn bind_device_by_index_v4(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
         let index = interface.map_or(0, NonZeroU32::get);
-        unsafe { setsockopt(self.as_raw(), IPPROTO_IP, IP_BOUND_IF, index) }
+        unsafe { setsockopt(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF, index) }
     }
 
     /// Sets the value for `IPV6_BOUND_IF` option on this socket.
@@ -1899,7 +1869,7 @@ impl crate::Socket {
     ))]
     pub fn bind_device_by_index_v6(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
         let index = interface.map_or(0, NonZeroU32::get);
-        unsafe { setsockopt(self.as_raw(), IPPROTO_IPV6, IPV6_BOUND_IF, index) }
+        unsafe { setsockopt(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF, index) }
     }
 
     /// Gets the value for `IP_BOUND_IF` option on this socket, i.e. the index
@@ -1920,7 +1890,8 @@ impl crate::Socket {
         )
     ))]
     pub fn device_index_v4(&self) -> io::Result<Option<NonZeroU32>> {
-        let index = unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IP, IP_BOUND_IF)? };
+        let index =
+            unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF)? };
         Ok(NonZeroU32::new(index))
     }
 
@@ -1942,8 +1913,9 @@ impl crate::Socket {
         )
     ))]
     pub fn device_index_v6(&self) -> io::Result<Option<NonZeroU32>> {
-        let index =
-            unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IPV6, IPV6_BOUND_IF)? };
+        let index = unsafe {
+            getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF)?
+        };
         Ok(NonZeroU32::new(index))
     }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1391,7 +1391,7 @@ pub(crate) fn original_dst_ipv6(fd: Socket) -> io::Result<SockAddr> {
     .map(|(_, addr)| addr)
 }
 
-// TODO(eliza): use libc's definition on solarish once it merges...
+// TODO: remove this once https://github.com/rust-lang/libc/pull/4287 merges
 #[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
 const IP_BOUND_IF: libc::c_int = 0x41;
 #[cfg(all(
@@ -1406,6 +1406,7 @@ const IP_BOUND_IF: libc::c_int = 0x41;
 ))]
 use libc::IP_BOUND_IF;
 
+// TODO: remove this once https://github.com/rust-lang/libc/pull/4287 merges
 #[cfg(all(feature = "all", any(target_os = "illumos", target_os = "solaris")))]
 const IPV6_BOUND_IF: libc::c_int = 0x41;
 #[cfg(all(

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1391,6 +1391,29 @@ pub(crate) fn original_dst_ipv6(fd: Socket) -> io::Result<SockAddr> {
     .map(|(_, addr)| addr)
 }
 
+// TODO(eliza): use libc's definition on solarish once it merges...
+#[cfg(any(target_os = "illumos", target_os = "solaris",))]
+const IP_BOUND_IF: libc::c_int = 0x41;
+#[cfg(any(
+    target_os = "ios",
+    target_os = "visionos",
+    target_os = "macos",
+    target_os = "tvos",
+    target_os = "watchos",
+))]
+use libc::IP_BOUND_IF;
+
+#[cfg(any(target_os = "illumos", target_os = "solaris",))]
+const IPV6_BOUND_IF: libc::c_int = 0x41;
+#[cfg(any(
+    target_os = "ios",
+    target_os = "visionos",
+    target_os = "macos",
+    target_os = "tvos",
+    target_os = "watchos",
+))]
+use libc::IPV6_BOUND_IF;
+
 /// Unix only API.
 impl crate::Socket {
     /// Accept a new incoming connection from this listener.
@@ -1842,7 +1865,7 @@ impl crate::Socket {
     ))]
     pub fn bind_device_by_index_v4(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
         let index = interface.map_or(0, NonZeroU32::get);
-        unsafe { setsockopt(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF, index) }
+        unsafe { setsockopt(self.as_raw(), IPPROTO_IP, IP_BOUND_IF, index) }
     }
 
     /// Sets the value for `IPV6_BOUND_IF` option on this socket.
@@ -1869,7 +1892,7 @@ impl crate::Socket {
     ))]
     pub fn bind_device_by_index_v6(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
         let index = interface.map_or(0, NonZeroU32::get);
-        unsafe { setsockopt(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF, index) }
+        unsafe { setsockopt(self.as_raw(), IPPROTO_IPV6, IPV6_BOUND_IF, index) }
     }
 
     /// Gets the value for `IP_BOUND_IF` option on this socket, i.e. the index
@@ -1890,8 +1913,7 @@ impl crate::Socket {
         )
     ))]
     pub fn device_index_v4(&self) -> io::Result<Option<NonZeroU32>> {
-        let index =
-            unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IP, libc::IP_BOUND_IF)? };
+        let index = unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IP, IP_BOUND_IF)? };
         Ok(NonZeroU32::new(index))
     }
 
@@ -1913,9 +1935,8 @@ impl crate::Socket {
         )
     ))]
     pub fn device_index_v6(&self) -> io::Result<Option<NonZeroU32>> {
-        let index = unsafe {
-            getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IPV6, libc::IPV6_BOUND_IF)?
-        };
+        let index =
+            unsafe { getsockopt::<libc::c_uint>(self.as_raw(), IPPROTO_IPV6, IPV6_BOUND_IF)? };
         Ok(NonZeroU32::new(index))
     }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -22,6 +22,8 @@ use std::net::{Ipv4Addr, Ipv6Addr};
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "illumos",
+        target_os = "solaris",
     )
 ))]
 use std::num::NonZeroU32;
@@ -1834,6 +1836,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     pub fn bind_device_by_index_v4(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
@@ -1859,6 +1863,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     pub fn bind_device_by_index_v6(&self, interface: Option<NonZeroU32>) -> io::Result<()> {
@@ -1879,6 +1885,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     pub fn device_index_v4(&self) -> io::Result<Option<NonZeroU32>> {
@@ -1900,6 +1908,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     pub fn device_index_v6(&self) -> io::Result<Option<NonZeroU32>> {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -990,6 +990,8 @@ fn device() {
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "solaris",
+        target_os = "illumos",
     )
 ))]
 #[test]
@@ -1036,6 +1038,8 @@ fn device() {
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "solaris",
+        target_os = "illumos",
     )
 ))]
 #[test]


### PR DESCRIPTION
The `IP_BOUND_IF` socket option, which is wrapped by the
`Socket::bind_device_by_index_{v4,v6}` and
`Socket::device_index_{v4,v6}` is available on SunOS-like systems, such
as illumos and Solaris, as well as macOS-like systems. However, these
APIs are currently cfg-flagged to only be available on macOS-like
systems.

This commit changes the cfg attributes to also enable these APIs on
illumos and Solaris.

Fixes #560