### PR TITLE
Use IPV6_HDRINCL in set_header_included_v6() on Linux

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1674,6 +1674,9 @@ impl Socket {
             setsockopt(
                 self.as_raw(),
                 sys::IPPROTO_IPV6,
+                #[cfg(target_os = "linux")]
+                sys::IPV6_HDRINCL,
+                #[cfg(not(target_os = "linux"))]
                 sys::IP_HDRINCL,
                 included as c_int,
             )

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -124,6 +124,8 @@ pub(crate) use libc::SO_OOBINLINE;
 // Used in `Socket`.
 #[cfg(not(target_os = "nto"))]
 pub(crate) use libc::ipv6_mreq as Ipv6Mreq;
+#[cfg(all(feature = "all", target_os = "linux"))]
+pub(crate) use libc::IPV6_HDRINCL;
 #[cfg(all(
     feature = "all",
     not(any(


### PR DESCRIPTION
This pull request introduces a platform-specific configuration to use IPV6_HDRINCL in set_header_included_v6() on Linux. 

Background: Linux has defined IPv6 specific constant IPV6_HDRINCL (36) that needs to be used when setting HDRINCL socket option instead of IP_HDRINCL (2). Without it, set_header_included_v6() function does not work as expected and a kernel provided header is added to packets sent even if `set_header_included_v6(true)` is called on a raw socket. 

* [`src/socket.rs`](diffhunk://#diff-917ff224180b881299cdcef7bc14e710509229092ea4e6599861680bc0a2a458R1677-R1679): Added conditional compilation for `IPV6_HDRINCL` on Linux and `IP_HDRINCL` on non-Linux systems to the `setsockopt` function.
* [`src/sys/unix.rs`](diffhunk://#diff-bbdb7821e30b05ce3afbaa9fbc1526c18d6670d65479baaca3beaf4ea6174891R160-R161): Added conditional use of `libc::IPV6_HDRINCL` for Linux systems.