### PR TITLE
Enable `IP_BOUND_IF` on illumos and Solaris

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ targets = ["aarch64-apple-ios", "aarch64-linux-android", "x86_64-apple-darwin", 
 features = ["all"]
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.150"
+libc = "0.2.171"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -22,6 +22,8 @@ use std::net::{Ipv4Addr, Ipv6Addr};
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "illumos",
+        target_os = "solaris",
     )
 ))]
 use std::num::NonZeroU32;
@@ -2076,6 +2078,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     #[cfg_attr(
@@ -2114,6 +2118,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     #[cfg_attr(
@@ -2147,6 +2153,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     #[cfg_attr(
@@ -2210,6 +2218,8 @@ impl crate::Socket {
             target_os = "macos",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
         )
     ))]
     #[cfg_attr(

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -990,6 +990,8 @@ fn device() {
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "solaris",
+        target_os = "illumos",
     )
 ))]
 #[test]
@@ -1036,6 +1038,8 @@ fn device() {
         target_os = "macos",
         target_os = "tvos",
         target_os = "watchos",
+        target_os = "solaris",
+        target_os = "illumos",
     )
 ))]
 #[test]


### PR DESCRIPTION
The `IP_BOUND_IF` socket option, which is wrapped by the `Socket::bind_device_by_index_{v4,v6}` and
`Socket::device_index_{v4,v6}` is available on SunOS-like systems, such as illumos and Solaris, as well as macOS-like systems. However, these APIs are currently cfg-flagged to only be available on macOS-like systems.

This commit changes the cfg attributes to also enable these APIs on illumos and Solaris.

Fixes #560

This is a backport of PR #561 to the `v0.5.x` branch.