### PR TITLE
Add SockFilter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,6 @@ compile_error!("Socket2 doesn't support the compile target");
 use sys::c_int;
 
 pub use sockaddr::{sa_family_t, socklen_t, SockAddr, SockAddrStorage};
-pub use socket::Socket;
-pub use sockref::SockRef;
-
 #[cfg(not(any(
     target_os = "haiku",
     target_os = "illumos",
@@ -197,6 +194,10 @@ pub use sockref::SockRef;
     target_os = "solaris",
 )))]
 pub use socket::InterfaceIndexOrAddress;
+pub use socket::Socket;
+pub use sockref::SockRef;
+#[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
+pub use sys::SockFilter;
 
 /// Specification of the communication domain for a socket.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,8 @@ pub use sockaddr::{sa_family_t, socklen_t, SockAddr, SockAddrStorage};
 pub use socket::InterfaceIndexOrAddress;
 pub use socket::Socket;
 pub use sockref::SockRef;
+#[cfg(all(feature = "all", target_os = "linux"))]
+pub use sys::CcidEndpoints;
 #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
 pub use sys::SockFilter;
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -2844,6 +2844,8 @@ impl std::fmt::Debug for SockFilter {
 }
 
 /// See [`Socket::dccp_available_ccids`].
+///
+/// [`Socket::dccp_available_ccids`]: crate::Socket::dccp_available_ccids
 #[cfg(all(feature = "all", target_os = "linux"))]
 #[derive(Debug)]
 pub struct CcidEndpoints<const N: usize> {


### PR DESCRIPTION
A wrapper around libc::sock_filter, so we don't use any libc types in our API.