### PR TITLE
Use c_int from std::ffi instead of std::os::raw

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -83,7 +83,7 @@ use crate::{Domain, Protocol, SockAddr, SockAddrStorage, TcpKeepalive, Type};
 #[cfg(not(target_os = "redox"))]
 use crate::{MsgHdr, MsgHdrMut, RecvFlags};
 
-pub(crate) use std::os::raw::c_int;
+pub(crate) use std::ffi::c_int;
 
 // Used in `Domain`.
 pub(crate) use libc::{AF_INET, AF_INET6, AF_UNIX};

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -35,7 +35,7 @@ use windows_sys::Win32::System::Threading::INFINITE;
 use crate::{MsgHdr, RecvFlags, SockAddr, SockAddrStorage, TcpKeepalive, Type};
 
 #[allow(non_camel_case_types)]
-pub(crate) type c_int = std::os::raw::c_int;
+pub(crate) type c_int = std::ffi::c_int;
 
 /// Fake MSG_TRUNC flag for the [`RecvFlags`] struct.
 ///


### PR DESCRIPTION
As of 1.64 the canonical location to access these typedefs is `std::ffi`.