### PR TITLE
fix only_v6() panic on windows

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1932,10 +1932,13 @@ impl Socket {
     ///
     /// [`set_only_v6`]: Socket::set_only_v6
     pub fn only_v6(&self) -> io::Result<bool> {
+        #[cfg(not(windows))]
         unsafe {
-            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IPV6, sys::IPV6_V6ONLY)
+            getsockopt::<Bool>(self.as_raw(), sys::IPPROTO_IPV6, sys::IPV6_V6ONLY)
                 .map(|only_v6| only_v6 != 0)
         }
+        #[cfg(windows)]
+        sys::only_v6(self.as_raw())
     }
 
     /// Set the value for the `IPV6_V6ONLY` option on this socket.

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -892,6 +892,26 @@ pub(crate) fn to_mreqn(
     }
 }
 
+pub(crate) fn only_v6(socket: RawSocket) -> io::Result<bool> {
+    let mut optval: c_int = 0; // input must be 4 bytes (DWORD)
+    let mut optlen = mem::size_of_val(&optval) as c_int;
+    syscall!(
+        getsockopt(
+            socket,
+            IPPROTO_IPV6 as i32,
+            IPV6_V6ONLY,
+            ptr::from_mut(&mut optval).cast(),
+            &mut optlen,
+        ),
+        PartialEq::eq,
+        SOCKET_ERROR
+    )
+    .map(|_| {
+        // optlen may be 1, which won't match the input size of optval
+        optval != 0
+    })
+}
+
 #[cfg(feature = "all")]
 pub(crate) fn original_dst_v4(socket: RawSocket) -> io::Result<SockAddr> {
     unsafe {


### PR DESCRIPTION
I have encountered a panic case in only_v6 in github CI on windows:
https://github.com/bytedance/g3/actions/runs/16095794585/job/45418469197

The input buffer size (optlen) must be 4, and the output optlen may be 1. As the input optval is initialized to zero, it will be modified to nonzero when ipv6 only, so just use `optval != 0` to get the result value.