### PR TITLE
add IPV6_TRANSPARENT for tproxy

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1202,7 +1202,7 @@ impl Socket {
     /// For more information about this option, see [`set_ip_transparent_v4`].
     ///
     /// [`set_ip_transparent_v4`]: Socket::set_ip_transparent_v4
-    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
     pub fn ip_transparent_v4(&self) -> io::Result<bool> {
         unsafe {
             getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IP, libc::IP_TRANSPARENT)
@@ -1225,7 +1225,7 @@ impl Socket {
     ///
     /// TProxy redirection with the iptables TPROXY target also
     /// requires that this option be set on the redirected socket.
-    #[cfg(all(feature = "all", target_os = "linux"))]
+    #[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
     pub fn set_ip_transparent_v4(&self, transparent: bool) -> io::Result<()> {
         unsafe {
             setsockopt(

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1391,7 +1391,7 @@ test!(
     tcp_mss,
     set_tcp_mss(256)
 );
-#[cfg(all(feature = "all", target_os = "linux"))]
+#[cfg(all(feature = "all", any(target_os = "linux", target_os = "android")))]
 test!(
     #[ignore = "setting `IP_TRANSPARENT` requires the `CAP_NET_ADMIN` capability (works when running as root)"]
     IPv4 ip_transparent_v4,


### PR DESCRIPTION
Add the IPv6 transparent socket option for TPROXY on linux.  Also added a macro pattern for IPv4 and IPv6 sockets with attributes to allow the ignore directive to work with IPv4 and IPv6 only tests