### PR TITLE
Add TCP_NOTSENT_LOWAT socketopt support

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1807,6 +1807,35 @@ impl crate::Socket {
         }
     }
 
+    /// Get the value of the `TCP_NOTSENT_LOWAT` option on this socket.
+    ///
+    /// For more information about this option, see [`set_tcp_notsent_lowat`].
+    ///
+    /// [`set_tcp_notsent_lowat`]: crate::Socket::set_tcp_notsent_lowat
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    pub fn tcp_notsent_lowat(&self) -> io::Result<u32> {
+        unsafe {
+            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_NOTSENT_LOWAT)
+                .map(|lowat| lowat as u32)
+        }
+    }
+
+    /// Set the value of the `TCP_NOTSENT_LOWAT` option on this socket.
+    ///
+    /// If set the kernel will limit the amount of _unsent_ data in the sendbuffer.
+    /// This differs from `set_send_buffer_size` which limits the sum of unsent and unacknowledged data.
+    #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+    pub fn set_tcp_notsent_lowat(&self, lowat: u32) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                libc::IPPROTO_TCP,
+                libc::TCP_NOTSENT_LOWAT,
+                lowat as c_int,
+            )
+        }
+    }
+
     /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
     ///
     /// This value gets the socket binded device's interface name.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1458,6 +1458,8 @@ test!(tcp_quickack, set_tcp_quickack(false));
     any(target_os = "android", target_os = "fuchsia", target_os = "linux")
 ))]
 test!(tcp_thin_linear_timeouts, set_tcp_thin_linear_timeouts(true));
+#[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
+test!(tcp_notsent_lowat, set_tcp_notsent_lowat(16 * 1024));
 test!(linger, set_linger(Some(Duration::from_secs(10))));
 test!(
     read_timeout,


### PR DESCRIPTION
Useful option for latency-sensitive applications to reduce local bufferbloat by not putting (much) more than what's needed to fill the BDP into the send buffer.
I've put some some relevant links in the commit message.