### PR TITLE
Contribute a small example for how to use SockAddrStorage::view_as

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -54,6 +54,7 @@ impl SockAddrStorage {
     /// ```
     /// # #[allow(dead_code)]
     /// # #[cfg(unix)] mod unix_example {
+    /// # use core::mem::size_of;
     /// use libc::sockaddr_storage;
     /// use socket2::{SockAddr, SockAddrStorage, socklen_t};
     ///


### PR DESCRIPTION
In order to help demonstrate how to create a `SockAddr` from an instance of a `libc::sockaddr_storage`, @Thomasdezeeuw proposed adding an example in #613.

I also took the liberty of addressing a few markdownlint items in the readme and contributing docs... Hope that was okay.