### PR TITLE
Update feature `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 
 #![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 // Automatically generate required OS/features for docs.rs.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // Disallow warnings when running tests.
 #![cfg_attr(test, deny(warnings))]
 // Disallow warnings in examples.


### PR DESCRIPTION
`doc_auto_cfg` has been removed in the latest nightly, see https://github.com/rust-lang/rust/pull/138907. This feature was merged into `doc_cfg`.

This fixes the rustdoc build in the latest nightly toolchain with `docsrs` feature enabled.

Otherwise, it will break like:
```
$ RUSTDOCFLAGS="--cfg docsrs" RUSTFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 Documenting socket2 v0.6.0 (/Users/shiroko/Projects/socket2)
error[E0557]: feature has been removed
  --> src/lib.rs:57:29
   |
57 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0557`.
error: could not document `socket2`
```