### PR TITLE
Update to windows-sys 0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = ["all"]
 libc = "0.2.172"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.60"
+version = ">=0.60, <0.62"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",


### PR DESCRIPTION
Tokio and mio already updated to windows-sys 0.61, so socket2 requiring 0.60 makes it hard to avoid multiple copies of windows-sys. In addition, 0.61 finally drops the dependency on large pre-built import libraries (from `windows-targets`) in favor of [Rust's raw-dylib feature](https://doc.rust-lang.org/reference/items/external-blocks.html#dylib-versus-raw-dylib).

Since no code changes are needed, I relaxed the version requirement (still allowing 0.60) to avoid increasing socket2's MSRV.