### PR TITLE
fix getsockopt generic argument in notsent_lowat

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1815,7 +1815,7 @@ impl crate::Socket {
     #[cfg(all(feature = "all", any(target_os = "android", target_os = "linux")))]
     pub fn tcp_notsent_lowat(&self) -> io::Result<u32> {
         unsafe {
-            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_NOTSENT_LOWAT)
+            getsockopt::<c_int>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_NOTSENT_LOWAT)
                 .map(|lowat| lowat as u32)
         }
     }


### PR DESCRIPTION
small cleanup after #611
I made a copy-paste error there: notsent_lowat is not a boolean but a value. `Bool` is an alias for `c_int` so this doesn't make a real difference, but it's semantically the wrong type and might confuse future readers.