### PR TITLE
refactor(windows): update windows-sys version and improve socket flag…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = ["all"]
 libc = "0.2.172"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.60"
+version = "0.61.2"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",


### PR DESCRIPTION
… handling

- Update windows-sys dependency from 0.60 to 0.61.2
- Replace manual bit calculations with c_int::BITS for better clarity
- Simplify bitwise operations and remove redundant type casts
- Use direct enum values instead of casting to i32 where possible