### PR TITLE
Fixed cfg in original_dst_v6 test (#625)

### DIFF
--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1723,7 +1723,7 @@ fn original_dst_v4() {
 #[test]
 #[cfg(all(
     feature = "all",
-    any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+    any(target_os = "android", target_os = "linux", target_os = "windows")
 ))]
 fn original_dst_v6() {
     let socket = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();


### PR DESCRIPTION
Fixed cfg in test. Please merge, so "make test_all" works again.