### PR TITLE
Re-enable CI check for armv7-sony-vita-newlibeabihf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,7 @@ jobs:
           - arm-linux-androideabi
           - arm64_32-apple-watchos
           - armv7-linux-androideabi
-          # Broken, see https://github.com/rust-lang/rust/issues/147437.
-          #- armv7-sony-vita-newlibeabihf
+          - armv7-sony-vita-newlibeabihf
           - armv7-unknown-linux-ohos
           - i686-linux-android
           # Broken, see https://github.com/rust-lang/socket2/issues/539.


### PR DESCRIPTION
This basically reverts b54e2e6dbf44baee462afb48285d6595e5800381

As nightly is now compiling again, we should be able to re-enable CI for this target.