### PR TITLE
make `MsgHdr` and `MsgHdrMut` `repr(transparent)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,6 +562,7 @@ impl TcpKeepalive {
 /// This wraps `msghdr` on Unix and `WSAMSG` on Windows. Also see [`MsgHdrMut`]
 /// for the variant used by `recvmsg(2)`.
 #[cfg(not(target_os = "redox"))]
+#[repr(transparent)]
 pub struct MsgHdr<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
     #[allow(clippy::type_complexity)]
@@ -630,6 +631,7 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdr<'name, 'bufs, 'control> {
 /// This wraps `msghdr` on Unix and `WSAMSG` on Windows. Also see [`MsgHdr`] for
 /// the variant used by `sendmsg(2)`.
 #[cfg(not(target_os = "redox"))]
+#[repr(transparent)]
 pub struct MsgHdrMut<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
Closes #633

This PR simply adds `#[repr(transparent)]` to corresponding types, without any methods for conversion on the types themselves.