### PR TITLE
Implement Send for MsgHdr and MsgHdrMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,6 +638,9 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdr<'name, 'bufs, 'control> {
     }
 }
 
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+unsafe impl Send for MsgHdr<'_, '_, '_> {}
+
 /// Configuration of a `recvmsg(2)` system call.
 ///
 /// This wraps `msghdr` on Unix and `WSAMSG` on Windows. Also see [`MsgHdr`] for
@@ -715,3 +718,6 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdrMut<'name, 'bufs, 'control> {
         "MsgHdrMut".fmt(fmt)
     }
 }
+
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+unsafe impl Send for MsgHdrMut<'_, '_, '_> {}


### PR DESCRIPTION
Allow MsgHdr and MsgHdrMut structs to be moved between threads. This is useful when using sendmsg() or recvmsg() calls on a non blocking socket from a spawned async task where the future would need to be Send.