### PR TITLE
fix: fixes invalid libc symbols on horizon-os/n3ds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,7 @@ jobs:
           - aarch64-unknown-redox
           - arm-linux-androideabi
           - arm64_32-apple-watchos
+          - armv6k-nintendo-3ds
           - armv7-linux-androideabi
           - armv7-sony-vita-newlibeabihf
           - armv7-unknown-linux-ohos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,13 +279,13 @@ impl Type {
     pub const DCCP: Type = Type(sys::SOCK_DCCP);
 
     /// Type corresponding to `SOCK_SEQPACKET`.
-    #[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi"))))]
+    #[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))))]
     pub const SEQPACKET: Type = Type(sys::SOCK_SEQPACKET);
 
     /// Type corresponding to `SOCK_RAW`.
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi"))
+        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
     ))]
     pub const RAW: Type = Type(sys::SOCK_RAW);
 }
@@ -371,11 +371,11 @@ impl From<Protocol> for c_int {
 /// Flags for incoming messages.
 ///
 /// Flags provide additional information about incoming messages.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct RecvFlags(c_int);
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl RecvFlags {
     /// Check if the message contains a truncated datagram.
     ///
@@ -384,7 +384,7 @@ impl RecvFlags {
     ///
     /// On Unix this corresponds to the `MSG_TRUNC` flag.
     /// On Windows this corresponds to the `WSAEMSGSIZE` error code.
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf")))]
     pub const fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
     }
@@ -573,7 +573,7 @@ impl TcpKeepalive {
 ///
 /// This wraps `msghdr` on Unix and `WSAMSG` on Windows. Also see [`MsgHdrMut`]
 /// for the variant used by `recvmsg(2)`.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 #[repr(transparent)]
 pub struct MsgHdr<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
@@ -581,7 +581,7 @@ pub struct MsgHdr<'addr, 'bufs, 'control> {
     _lifetimes: PhantomData<(&'addr SockAddr, &'bufs IoSlice<'bufs>, &'control [u8])>,
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl<'addr, 'bufs, 'control> MsgHdr<'addr, 'bufs, 'control> {
     /// Create a new `MsgHdr` with all empty/zero fields.
     #[allow(clippy::new_without_default)]
@@ -631,21 +631,21 @@ impl<'addr, 'bufs, 'control> MsgHdr<'addr, 'bufs, 'control> {
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl<'name, 'bufs, 'control> fmt::Debug for MsgHdr<'name, 'bufs, 'control> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         "MsgHdr".fmt(fmt)
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 unsafe impl Send for MsgHdr<'_, '_, '_> {}
 
 /// Configuration of a `recvmsg(2)` system call.
 ///
 /// This wraps `msghdr` on Unix and `WSAMSG` on Windows. Also see [`MsgHdr`] for
 /// the variant used by `sendmsg(2)`.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 #[repr(transparent)]
 pub struct MsgHdrMut<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
@@ -657,7 +657,7 @@ pub struct MsgHdrMut<'addr, 'bufs, 'control> {
     )>,
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl<'addr, 'bufs, 'control> MsgHdrMut<'addr, 'bufs, 'control> {
     /// Create a new `MsgHdrMut` with all empty/zero fields.
     #[allow(clippy::new_without_default)]
@@ -712,12 +712,12 @@ impl<'addr, 'bufs, 'control> MsgHdrMut<'addr, 'bufs, 'control> {
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl<'name, 'bufs, 'control> fmt::Debug for MsgHdrMut<'name, 'bufs, 'control> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         "MsgHdrMut".fmt(fmt)
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 unsafe impl Send for MsgHdrMut<'_, '_, '_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,11 @@
 #![doc(test(attr(deny(warnings))))]
 
 use std::fmt;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use std::io::IoSlice;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use std::marker::PhantomData;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use std::mem;
 use std::mem::MaybeUninit;
 use std::net::SocketAddr;
@@ -279,13 +279,21 @@ impl Type {
     pub const DCCP: Type = Type(sys::SOCK_DCCP);
 
     /// Type corresponding to `SOCK_SEQPACKET`.
-    #[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))))]
+    #[cfg(all(
+        feature = "all",
+        not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+    ))]
     pub const SEQPACKET: Type = Type(sys::SOCK_SEQPACKET);
 
     /// Type corresponding to `SOCK_RAW`.
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+        not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "wasi",
+            target_os = "horizon"
+        ))
     ))]
     pub const RAW: Type = Type(sys::SOCK_RAW);
 }
@@ -384,7 +392,7 @@ impl RecvFlags {
     ///
     /// On Unix this corresponds to the `MSG_TRUNC` flag.
     /// On Windows this corresponds to the `WSAEMSGSIZE` error code.
-    #[cfg(not(any(target_os = "espidf")))]
+    #[cfg(not(target_os = "espidf"))]
     pub const fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
     }
@@ -445,6 +453,7 @@ pub struct TcpKeepalive {
         target_os = "espidf",
         target_os = "vita",
         target_os = "haiku",
+        target_os = "horizon"
     )))]
     interval: Option<Duration>,
     #[cfg(not(any(
@@ -455,6 +464,7 @@ pub struct TcpKeepalive {
         target_os = "espidf",
         target_os = "vita",
         target_os = "haiku",
+        target_os = "horizon"
     )))]
     retries: Option<u32>,
 }
@@ -473,6 +483,7 @@ impl TcpKeepalive {
                 target_os = "espidf",
                 target_os = "vita",
                 target_os = "haiku",
+                target_os = "horizon"
             )))]
             interval: None,
             #[cfg(not(any(
@@ -483,6 +494,7 @@ impl TcpKeepalive {
                 target_os = "espidf",
                 target_os = "vita",
                 target_os = "haiku",
+                target_os = "horizon"
             )))]
             retries: None,
         }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -8,7 +8,7 @@
 
 use std::fmt;
 use std::io::{self, Read, Write};
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use std::io::{IoSlice, IoSliceMut};
 use std::mem::MaybeUninit;
 #[cfg(not(target_os = "nto"))]
@@ -21,7 +21,7 @@ use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 use std::time::Duration;
 
 use crate::sys::{self, c_int, getsockopt, setsockopt, Bool};
-#[cfg(all(unix, not(any(target_os = "horizon", target_os = "redox"))))]
+#[cfg(all(unix, not(any(target_os = "redox", target_os = "horizon"))))]
 use crate::MsgHdrMut;
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
 #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
@@ -632,7 +632,7 @@ impl Socket {
     /// <https://github.com/microsoft/Windows-classic-samples/blob/7cbd99ac1d2b4a0beffbaba29ea63d024ceff700/Samples/Win7Samples/netds/winsock/recvmsg/rmmc.cpp>
     /// for an example (in C++).
     #[doc = man_links!(recvmsg(2))]
-    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
+    #[cfg(all(unix, not(any(target_os = "redox", target_os = "horizon"))))]
     pub fn recvmsg(&self, msg: &mut MsgHdrMut<'_, '_, '_>, flags: sys::c_int) -> io::Result<usize> {
         sys::recvmsg(self.as_raw(), msg, flags)
     }
@@ -1211,7 +1211,12 @@ impl Socket {
     /// [`set_header_included_v4`]: Socket::set_header_included_v4
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+        not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "wasi",
+            target_os = "horizon"
+        ))
     ))]
     pub fn header_included_v4(&self) -> io::Result<bool> {
         unsafe {
@@ -1237,7 +1242,12 @@ impl Socket {
     )]
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+        not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "wasi",
+            target_os = "horizon"
+        ))
     ))]
     pub fn set_header_included_v4(&self, included: bool) -> io::Result<()> {
         unsafe {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -21,10 +21,10 @@ use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 use std::time::Duration;
 
 use crate::sys::{self, c_int, getsockopt, setsockopt, Bool};
-#[cfg(all(unix, not(target_os = "redox")))]
+#[cfg(all(unix, not(any(target_os = "horizon", target_os = "redox"))))]
 use crate::MsgHdrMut;
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use crate::{MaybeUninitSlice, MsgHdr, RecvFlags};
 
 /// Owned wrapper around a system socket.
@@ -470,7 +470,7 @@ impl Socket {
     /// Note that the [`io::Read::read_vectored`] implementation calls this
     /// function with `buf`s of type `&mut [IoSliceMut]`, allowing initialised
     /// buffers to be used without using `unsafe`.
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn recv_vectored(
         &self,
         bufs: &mut [MaybeUninitSlice<'_>],
@@ -489,7 +489,7 @@ impl Socket {
     /// as [`recv_vectored`].
     ///
     /// [`recv_vectored`]: Socket::recv_vectored
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn recv_vectored_with_flags(
         &self,
         bufs: &mut [MaybeUninitSlice<'_>],
@@ -554,7 +554,7 @@ impl Socket {
     /// as [`recv_vectored`].
     ///
     /// [`recv_vectored`]: Socket::recv_vectored
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn recv_from_vectored(
         &self,
         bufs: &mut [MaybeUninitSlice<'_>],
@@ -573,7 +573,7 @@ impl Socket {
     /// as [`recv_vectored`].
     ///
     /// [`recv_vectored`]: Socket::recv_vectored
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn recv_from_vectored_with_flags(
         &self,
         bufs: &mut [MaybeUninitSlice<'_>],
@@ -632,7 +632,7 @@ impl Socket {
     /// <https://github.com/microsoft/Windows-classic-samples/blob/7cbd99ac1d2b4a0beffbaba29ea63d024ceff700/Samples/Win7Samples/netds/winsock/recvmsg/rmmc.cpp>
     /// for an example (in C++).
     #[doc = man_links!(recvmsg(2))]
-    #[cfg(all(unix, not(target_os = "redox")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn recvmsg(&self, msg: &mut MsgHdrMut<'_, '_, '_>, flags: sys::c_int) -> io::Result<usize> {
         sys::recvmsg(self.as_raw(), msg, flags)
     }
@@ -657,7 +657,7 @@ impl Socket {
     }
 
     /// Send data to the connected peer. Returns the amount of bytes written.
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.send_vectored_with_flags(bufs, 0)
     }
@@ -667,7 +667,7 @@ impl Socket {
     #[doc = man_links!(sendmsg(2))]
     ///
     /// [`send_vectored`]: Socket::send_vectored
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn send_vectored_with_flags(
         &self,
         bufs: &[IoSlice<'_>],
@@ -714,7 +714,7 @@ impl Socket {
     /// Send data to a peer listening on `addr`. Returns the amount of bytes
     /// written.
     #[doc = man_links!(sendmsg(2))]
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn send_to_vectored(&self, bufs: &[IoSlice<'_>], addr: &SockAddr) -> io::Result<usize> {
         self.send_to_vectored_with_flags(bufs, addr, 0)
     }
@@ -723,7 +723,7 @@ impl Socket {
     /// arbitrary flags to the underlying `sendmsg`/`WSASendTo` call.
     ///
     /// [`send_to_vectored`]: Socket::send_to_vectored
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn send_to_vectored_with_flags(
         &self,
         bufs: &[IoSlice<'_>],
@@ -735,7 +735,7 @@ impl Socket {
 
     /// Send a message on a socket using a message structure.
     #[doc = man_links!(sendmsg(2))]
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     pub fn sendmsg(&self, msg: &MsgHdr<'_, '_, '_>, flags: sys::c_int) -> io::Result<usize> {
         sys::sendmsg(self.as_raw(), msg, flags)
     }
@@ -1211,7 +1211,7 @@ impl Socket {
     /// [`set_header_included_v4`]: Socket::set_header_included_v4
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi"))
+        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
     ))]
     pub fn header_included_v4(&self) -> io::Result<bool> {
         unsafe {
@@ -1237,7 +1237,7 @@ impl Socket {
     )]
     #[cfg(all(
         feature = "all",
-        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi"))
+        not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
     ))]
     pub fn set_header_included_v4(&self, included: bool) -> io::Result<()> {
         unsafe {
@@ -1344,6 +1344,7 @@ impl Socket {
         target_os = "vita",
         target_os = "cygwin",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn join_multicast_v4_n(
         &self,
@@ -1379,6 +1380,7 @@ impl Socket {
         target_os = "vita",
         target_os = "cygwin",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn leave_multicast_v4_n(
         &self,
@@ -1415,6 +1417,7 @@ impl Socket {
         target_os = "espidf",
         target_os = "vita",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn join_ssm_v4(
         &self,
@@ -1454,6 +1457,7 @@ impl Socket {
         target_os = "espidf",
         target_os = "vita",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn leave_ssm_v4(
         &self,
@@ -1677,6 +1681,7 @@ impl Socket {
         target_os = "vita",
         target_os = "cygwin",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn set_recv_tos_v4(&self, recv_tos: bool) -> io::Result<()> {
         unsafe {
@@ -1710,6 +1715,7 @@ impl Socket {
         target_os = "vita",
         target_os = "cygwin",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn recv_tos_v4(&self) -> io::Result<bool> {
         unsafe {
@@ -1754,6 +1760,7 @@ impl Socket {
             target_os = "dragonfly",
             target_os = "netbsd",
             target_os = "wasi",
+            target_os = "horizon"
         ))
     ))]
     pub fn header_included_v6(&self) -> io::Result<bool> {
@@ -1785,6 +1792,7 @@ impl Socket {
             target_os = "dragonfly",
             target_os = "netbsd",
             target_os = "wasi",
+            target_os = "horizon"
         ))
     ))]
     pub fn set_header_included_v6(&self, included: bool) -> io::Result<()> {
@@ -2084,6 +2092,7 @@ impl Socket {
         target_os = "espidf",
         target_os = "vita",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn recv_tclass_v6(&self) -> io::Result<bool> {
         unsafe {
@@ -2110,6 +2119,7 @@ impl Socket {
         target_os = "espidf",
         target_os = "vita",
         target_os = "wasi",
+        target_os = "horizon"
     )))]
     pub fn set_recv_tclass_v6(&self, recv_tclass: bool) -> io::Result<()> {
         unsafe {
@@ -2144,6 +2154,7 @@ impl Socket {
             target_os = "vita",
             target_os = "cygwin",
             target_os = "wasi",
+            target_os = "horizon"
         ))
     ))]
     pub fn recv_hoplimit_v6(&self) -> io::Result<bool> {
@@ -2174,6 +2185,7 @@ impl Socket {
             target_os = "vita",
             target_os = "cygwin",
             target_os = "wasi",
+            target_os = "horizon"
         ))
     ))]
     pub fn set_recv_hoplimit_v6(&self, recv_hoplimit: bool) -> io::Result<()> {
@@ -2373,7 +2385,7 @@ impl Read for Socket {
         self.recv(buf)
     }
 
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
         // same layout, that of `iovec`/`WSABUF`. Furthermore, `recv_vectored`
@@ -2391,7 +2403,7 @@ impl<'a> Read for &'a Socket {
         self.recv(buf)
     }
 
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         // Safety: see other `Read::read` impl.
         let bufs = unsafe { &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [MaybeUninitSlice<'_>]) };
@@ -2404,7 +2416,7 @@ impl Write for Socket {
         self.send(buf)
     }
 
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.send_vectored(bufs)
     }
@@ -2419,7 +2431,7 @@ impl<'a> Write for &'a Socket {
         self.send(buf)
     }
 
-    #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.send_vectored(bufs)
     }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1549,6 +1549,7 @@ impl crate::Socket {
             target_os = "tvos",
             target_os = "watchos",
             target_os = "wasi",
+            target_os = "horizon"
         ),
         allow(rustdoc::broken_intra_doc_links)
     )]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -9,7 +9,7 @@
 use std::cmp::min;
 #[cfg(not(target_os = "wasi"))]
 use std::ffi::OsStr;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use std::io::IoSlice;
 use std::marker::PhantomData;
 use std::mem::{self, size_of, MaybeUninit};
@@ -84,10 +84,18 @@ pub(crate) use libc::{AF_INET, AF_INET6};
 pub(crate) use libc::SOCK_DCCP;
 #[cfg(all(
     feature = "all",
-    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+    not(any(
+        target_os = "redox",
+        target_os = "espidf",
+        target_os = "wasi",
+        target_os = "horizon"
+    ))
 ))]
 pub(crate) use libc::SOCK_RAW;
-#[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))))]
+#[cfg(all(
+    feature = "all",
+    not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+))]
 pub(crate) use libc::SOCK_SEQPACKET;
 pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
 // Used in `Protocol`.
@@ -117,7 +125,12 @@ pub(crate) use libc::{
     sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t,
 };
 // Used in `RecvFlags`.
-#[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon")))]
+#[cfg(not(any(
+    target_os = "redox",
+    target_os = "espidf",
+    target_os = "wasi",
+    target_os = "horizon"
+)))]
 pub(crate) use libc::MSG_TRUNC;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) use libc::SO_OOBINLINE;
@@ -164,7 +177,12 @@ pub(crate) use libc::IPV6_RECVHOPLIMIT;
 pub(crate) use libc::IPV6_RECVTCLASS;
 #[cfg(all(
     feature = "all",
-    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
+    not(any(
+        target_os = "redox",
+        target_os = "espidf",
+        target_os = "wasi",
+        target_os = "horizon"
+    ))
 ))]
 pub(crate) use libc::IP_HDRINCL;
 #[cfg(not(any(
@@ -509,7 +527,12 @@ impl_debug!(
     libc::SOCK_DGRAM,
     #[cfg(all(feature = "all", target_os = "linux"))]
     libc::SOCK_DCCP,
-    #[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon")))]
+    #[cfg(not(any(
+        target_os = "redox",
+        target_os = "espidf",
+        target_os = "wasi",
+        target_os = "horizon"
+    )))]
     libc::SOCK_RAW,
     #[cfg(not(any(
         target_os = "redox",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -70,7 +70,7 @@ use libc::{in6_addr, in_addr};
 #[cfg(not(target_os = "wasi"))]
 use crate::SockAddrStorage;
 use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 use crate::{MsgHdr, MsgHdrMut, RecvFlags};
 
 pub(crate) use std::ffi::c_int;
@@ -84,10 +84,10 @@ pub(crate) use libc::{AF_INET, AF_INET6};
 pub(crate) use libc::SOCK_DCCP;
 #[cfg(all(
     feature = "all",
-    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi"))
+    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
 ))]
 pub(crate) use libc::SOCK_RAW;
-#[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi"))))]
+#[cfg(all(feature = "all", not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon"))))]
 pub(crate) use libc::SOCK_SEQPACKET;
 pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
 // Used in `Protocol`.
@@ -117,7 +117,7 @@ pub(crate) use libc::{
     sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t,
 };
 // Used in `RecvFlags`.
-#[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon")))]
 pub(crate) use libc::MSG_TRUNC;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) use libc::SO_OOBINLINE;
@@ -142,6 +142,7 @@ pub(crate) use libc::IPV6_HDRINCL;
         target_os = "vita",
         target_os = "wasi",
         target_os = "cygwin",
+        target_os = "horizon"
     ))
 ))]
 pub(crate) use libc::IPV6_RECVHOPLIMIT;
@@ -158,11 +159,12 @@ pub(crate) use libc::IPV6_RECVHOPLIMIT;
     target_os = "espidf",
     target_os = "vita",
     target_os = "wasi",
+    target_os = "horizon"
 )))]
 pub(crate) use libc::IPV6_RECVTCLASS;
 #[cfg(all(
     feature = "all",
-    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi"))
+    not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon"))
 ))]
 pub(crate) use libc::IP_HDRINCL;
 #[cfg(not(any(
@@ -181,6 +183,7 @@ pub(crate) use libc::IP_HDRINCL;
     target_os = "vita",
     target_os = "wasi",
     target_os = "cygwin",
+    target_os = "horizon"
 )))]
 pub(crate) use libc::IP_RECVTOS;
 #[cfg(not(any(
@@ -233,6 +236,7 @@ pub(crate) use libc::{
     target_os = "espidf",
     target_os = "vita",
     target_os = "wasi",
+    target_os = "horizon"
 )))]
 pub(crate) use libc::{
     ip_mreq_source as IpMreqSource, IP_ADD_SOURCE_MEMBERSHIP, IP_DROP_SOURCE_MEMBERSHIP,
@@ -505,16 +509,17 @@ impl_debug!(
     libc::SOCK_DGRAM,
     #[cfg(all(feature = "all", target_os = "linux"))]
     libc::SOCK_DCCP,
-    #[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "redox", target_os = "espidf", target_os = "wasi", target_os = "horizon")))]
     libc::SOCK_RAW,
     #[cfg(not(any(
         target_os = "redox",
         target_os = "haiku",
         target_os = "espidf",
-        target_os = "wasi"
+        target_os = "wasi",
+        target_os = "horizon"
     )))]
     libc::SOCK_RDM,
-    #[cfg(not(any(target_os = "espidf", target_os = "wasi")))]
+    #[cfg(not(any(target_os = "espidf", target_os = "wasi", target_os = "horizon")))]
     libc::SOCK_SEQPACKET,
     /* TODO: add these optional bit OR-ed flags:
     #[cfg(any(
@@ -569,7 +574,7 @@ impl_debug!(
 );
 
 /// Unix-only API.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl RecvFlags {
     /// Check if the message terminates a record.
     ///
@@ -580,7 +585,7 @@ impl RecvFlags {
     /// On Unix this corresponds to the `MSG_EOR` flag.
     ///
     /// [`SEQPACKET`]: Type::SEQPACKET
-    #[cfg(not(target_os = "espidf"))]
+    #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
     pub const fn is_end_of_record(self) -> bool {
         self.0 & libc::MSG_EOR != 0
     }
@@ -622,11 +627,11 @@ impl RecvFlags {
     }
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 impl std::fmt::Debug for RecvFlags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("RecvFlags");
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
         s.field("is_end_of_record", &self.is_end_of_record());
         s.field("is_out_of_band", &self.is_out_of_band());
         #[cfg(not(target_os = "espidf"))]
@@ -727,39 +732,39 @@ pub(crate) fn unix_sockaddr(path: &Path) -> io::Result<SockAddr> {
 }
 
 // Used in `MsgHdr`.
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) use libc::msghdr;
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn set_msghdr_name(msg: &mut msghdr, name: &SockAddr) {
     msg.msg_name = name.as_ptr() as *mut _;
     msg.msg_namelen = name.len();
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 #[allow(clippy::unnecessary_cast)] // IovLen type can be `usize`.
 pub(crate) fn set_msghdr_iov(msg: &mut msghdr, ptr: *mut libc::iovec, len: usize) {
     msg.msg_iov = ptr;
     msg.msg_iovlen = min(len, IovLen::MAX as usize) as IovLen;
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn set_msghdr_control(msg: &mut msghdr, ptr: *mut libc::c_void, len: usize) {
     msg.msg_control = ptr;
     msg.msg_controllen = len as _;
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn set_msghdr_flags(msg: &mut msghdr, flags: c_int) {
     msg.msg_flags = flags;
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn msghdr_flags(msg: &msghdr) -> RecvFlags {
     RecvFlags(msg.msg_flags)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn msghdr_control_len(msg: &msghdr) -> usize {
     msg.msg_controllen as _
 }
@@ -1086,7 +1091,7 @@ pub(crate) fn peek_sender(fd: RawSocket) -> io::Result<SockAddr> {
     Ok(sender)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn recv_vectored(
     fd: RawSocket,
     bufs: &mut [crate::MaybeUninitSlice<'_>],
@@ -1097,7 +1102,7 @@ pub(crate) fn recv_vectored(
     Ok((n, msg.flags()))
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn recv_from_vectored(
     fd: RawSocket,
     bufs: &mut [crate::MaybeUninitSlice<'_>],
@@ -1119,7 +1124,7 @@ pub(crate) fn recv_from_vectored(
     Ok((n, msg.flags(), addr))
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn recvmsg(
     fd: RawSocket,
     msg: &mut MsgHdrMut<'_, '_, '_>,
@@ -1138,7 +1143,7 @@ pub(crate) fn send(fd: RawSocket, buf: &[u8], flags: c_int) -> io::Result<usize>
     .map(|n| n as usize)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn send_vectored(
     fd: RawSocket,
     bufs: &[IoSlice<'_>],
@@ -1165,7 +1170,7 @@ pub(crate) fn send_to(
     .map(|n| n as usize)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn send_to_vectored(
     fd: RawSocket,
     bufs: &[IoSlice<'_>],
@@ -1176,7 +1181,7 @@ pub(crate) fn send_to_vectored(
     sendmsg(fd, &msg, flags)
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "horizon")))]
 pub(crate) fn sendmsg(fd: RawSocket, msg: &MsgHdr<'_, '_, '_>, flags: c_int) -> io::Result<usize> {
     syscall!(sendmsg(fd, &msg.inner, flags)).map(|n| n as usize)
 }
@@ -1398,6 +1403,7 @@ pub(crate) fn from_in6_addr(addr: in6_addr) -> Ipv6Addr {
     target_os = "vita",
     target_os = "cygwin",
     target_os = "wasi",
+    target_os = "horizon"
 )))]
 pub(crate) const fn to_mreqn(
     multiaddr: &Ipv4Addr,


### PR DESCRIPTION
HorizonOS (as used on the Nintendo 3DS) doesn't support all the calls/features currently expected. This PR just configures them all out, same as is done on wasi/espidf/redox.