### PR TITLE
Split target_os = "nto" cfg by env so io-sock variants use TCP_KEEPIDLE

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -298,11 +298,17 @@ pub(crate) use libc::{TCP_KEEPCNT, TCP_KEEPINTVL};
 // See this type in the Windows file.
 pub(crate) type Bool = c_int;
 
+// QNX legacy io-pkt stack (nto70, nto71) exposes TCP_KEEPALIVE.
+// The newer io-sock stack (nto71_iosock, nto80) replaced it with the
+// BSD-style TCP_KEEPIDLE — handle both branches below.
 #[cfg(any(
     target_os = "ios",
     target_os = "visionos",
     target_os = "macos",
-    target_os = "nto",
+    all(
+        target_os = "nto",
+        any(target_env = "nto70", target_env = "nto71"),
+    ),
     target_os = "tvos",
     target_os = "watchos",
 ))]
@@ -312,7 +318,10 @@ use libc::TCP_KEEPALIVE as KEEPALIVE_TIME;
     target_os = "ios",
     target_os = "visionos",
     target_os = "macos",
-    target_os = "nto",
+    all(
+        target_os = "nto",
+        any(target_env = "nto70", target_env = "nto71"),
+    ),
     target_os = "openbsd",
     target_os = "tvos",
     target_os = "watchos",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -298,9 +298,6 @@ pub(crate) use libc::{TCP_KEEPCNT, TCP_KEEPINTVL};
 // See this type in the Windows file.
 pub(crate) type Bool = c_int;
 
-// QNX legacy io-pkt stack (nto70, nto71) exposes TCP_KEEPALIVE.
-// The newer io-sock stack (nto71_iosock, nto80) replaced it with the
-// BSD-style TCP_KEEPIDLE — handle both branches below.
 #[cfg(any(
     target_os = "ios",
     target_os = "visionos",

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -302,10 +302,7 @@ pub(crate) type Bool = c_int;
     target_os = "ios",
     target_os = "visionos",
     target_os = "macos",
-    all(
-        target_os = "nto",
-        any(target_env = "nto70", target_env = "nto71"),
-    ),
+    all(target_os = "nto", any(target_env = "nto70", target_env = "nto71"),),
     target_os = "tvos",
     target_os = "watchos",
 ))]
@@ -315,10 +312,7 @@ use libc::TCP_KEEPALIVE as KEEPALIVE_TIME;
     target_os = "ios",
     target_os = "visionos",
     target_os = "macos",
-    all(
-        target_os = "nto",
-        any(target_env = "nto70", target_env = "nto71"),
-    ),
+    all(target_os = "nto", any(target_env = "nto70", target_env = "nto71"),),
     target_os = "openbsd",
     target_os = "tvos",
     target_os = "watchos",


### PR DESCRIPTION
QNX 8.0 (target_env = "nto80") ships only the io-sock network stack, which dropped TCP_KEEPALIVE in favour of the BSD-style TCP_KEEPIDLE. The same applies to QNX 7.1 with the optional io-sock stack (target_env = "nto71_iosock"). Only the legacy io-pkt envs (nto70, nto71) still expose TCP_KEEPALIVE.

Restricting the existing target_os = "nto" arms in the two KEEPALIVE_TIME aliases to the io-pkt envs lets io-sock variants fall through to the BSD-style TCP_KEEPIDLE arm that already exists. Requires the matching libc change (rust-lang/libc#5071) to land for the new constants to be visible.