### PR TITLE
Enable IP_TOS and IPV6_TCLASS on illumos

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1640,7 +1640,6 @@ impl Socket {
         target_os = "fuchsia",
         target_os = "redox",
         target_os = "solaris",
-        target_os = "illumos",
         target_os = "haiku",
         target_os = "wasi",
     )))]
@@ -1660,7 +1659,6 @@ impl Socket {
         target_os = "fuchsia",
         target_os = "redox",
         target_os = "solaris",
-        target_os = "illumos",
         target_os = "haiku",
         target_os = "wasi",
     )))]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -209,7 +209,6 @@ pub(crate) use libc::IP_RECVTOS;
     target_os = "redox",
     target_os = "solaris",
     target_os = "haiku",
-    target_os = "illumos",
     target_os = "wasi",
 )))]
 pub(crate) use libc::IP_TOS;
@@ -2643,6 +2642,7 @@ impl crate::Socket {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "cygwin",
+            target_os = "illumos",
         )
     ))]
     pub fn tclass_v6(&self) -> io::Result<u32> {
@@ -2668,6 +2668,7 @@ impl crate::Socket {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "cygwin",
+            target_os = "illumos",
         )
     ))]
     pub fn set_tclass_v6(&self, tclass: u32) -> io::Result<()> {

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1523,7 +1523,6 @@ test!(IPv4 ttl_v4, set_ttl_v4(40));
     target_os = "fuchsia",
     target_os = "redox",
     target_os = "solaris",
-    target_os = "illumos",
     target_os = "haiku",
     target_os = "cygwin",
     target_os = "wasi",
@@ -1577,7 +1576,8 @@ test!(IPv6 only_v6, set_only_v6(false));
         target_os = "linux",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "illumos"
     )
 ))]
 test!(IPv6 tclass_v6, set_tclass_v6(96));


### PR DESCRIPTION
IP_TOS and IPV6_TCLASS consts are already exposed by libc for Illumos. Enable the set_tos_v4/tos_v4 and tclass_v6/set_tclass_v6 wrappers for the illumos platform.

Manual run of tests `tos_v4` and `tclass_v6` succeed on illumos:
```
trey@korgano 08:27:10 PM | ~/git/socket2
‣ cargo nextest run --all-features tclass_v6 tos_v4
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
------------
 Nextest run ID 1dcf5449-2180-4dae-a7c8-d7c8d5fae7ea with nextest profile: default
    Starting 2 tests across 2 binaries (55 tests skipped)
        PASS [   0.009s] socket2::socket tclass_v6
        PASS [   0.010s] socket2::socket tos_v4
------------
     Summary [   0.012s] 2 tests run: 2 passed, 55 skipped

trey@korgano 08:27:14 PM | ~/git/socket2
‣ uname -a
SunOS korgano 5.11 helios-2.0.23819 i86pc i386 i86pc
```