### PR TITLE
nuttx: type IovLen to c_ulong

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -432,11 +432,12 @@ type IovLen = usize;
     target_os = "tvos",
     target_os = "watchos",
     target_os = "espidf",
-    target_os = "nuttx",
     target_os = "vita",
     target_os = "cygwin",
 ))]
 type IovLen = c_int;
+#[cfg(target_os = "nuttx")]
+type IovLen = libc::c_ulong;
 
 /// Unix only API.
 impl Domain {


### PR DESCRIPTION
The `msg_iovlen` is the `unsigned long` in the Nuttx.

The origin define is as follows, in nuttx/include/sys/socket.h
```
struct msghdr
{
  FAR void *msg_name;
  socklen_t msg_namelen;
  FAR struct iovec *msg_iov;
  unsigned long msg_iovlen;
  FAR void *msg_control;
  unsigned long msg_controllen;
  unsigned int msg_flags;
};
```